### PR TITLE
feature/accept current culture on Build method

### DIFF
--- a/RecordParser.Test/FixedLengthReaderBuilderTest.cs
+++ b/RecordParser.Test/FixedLengthReaderBuilderTest.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using RecordParser.Parsers;
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using Xunit;
@@ -16,7 +17,7 @@ namespace RecordParser.Test
                 .Map(x => x.Name, startIndex: 0, length: 11)
                 .Map(x => x.Birthday, 12, 10)
                 .Map(x => x.Money, 23, 7)
-                .Build();
+                .BuildForUnitTest();
 
             var result = reader.Parse("foo bar baz 2020.05.23 0123.45");
 
@@ -34,7 +35,7 @@ namespace RecordParser.Test
                 .Map(x => x.Debit, 22, 6)
                 .DefaultTypeConvert(value => decimal.Parse(value) / 100)
                 .DefaultTypeConvert(value => DateTime.ParseExact(value, "ddMMyyyy", null))
-                .Build();
+                .BuildForUnitTest();
 
             var result = reader.Parse("012345678901 23052020 012345");
 
@@ -51,7 +52,7 @@ namespace RecordParser.Test
                 .Map(x => x.Birthday, 12, 8, value => DateTime.ParseExact(value, "ddMMyyyy", null))
                 .Map(x => x.Money, 21, 7)
                 .Map(x => x.Nickname, 28, 8, value => value.Slice(0, 4).ToString())
-                .Build();
+                .BuildForUnitTest();
 
             var result = reader.Parse("foo bar baz 23052020 012345 nickname");
 
@@ -69,7 +70,7 @@ namespace RecordParser.Test
                 .Map(x => x.MotherAge, 4, 4)
                 .Map(x => x.FatherAge, 8, 4)
                 .DefaultTypeConvert(value => int.Parse(value) + 2)
-                .Build();
+                .BuildForUnitTest();
 
             var result = reader.Parse(" 15  40  50 ");
 
@@ -101,7 +102,7 @@ namespace RecordParser.Test
                 .Map(x => x.Foo, 0, 5)
                 .Map(x => x.Bar, 4, 5)
                 .Map(x => x.Baz, 8, 5)
-                .Build();
+                .BuildForUnitTest();
 
             var result = reader.Parse(" foo bar baz ");
 
@@ -116,7 +117,7 @@ namespace RecordParser.Test
             var reader = new FixedLengthReaderBuilder<(string Name, DateTime Birthday)>()
                 .Map(x => x.Name, 0, 5)
                 .Map(x => x.Birthday, 5, 10)
-                .Build();
+                .BuildForUnitTest();
 
             var parsed = reader.TryParse(" foo datehere", out var result);
 
@@ -131,7 +132,7 @@ namespace RecordParser.Test
                 .Map(x => x.Name, startIndex: 0, length: 11)
                 .Map(x => x.Birthday, 12, 10)
                 .Map(x => x.Money, 23, 7)
-                .Build();
+                .BuildForUnitTest();
 
             var parsed = reader.TryParse("foo bar baz 2020.05.23 0123.45", out var result);
 
@@ -150,7 +151,7 @@ namespace RecordParser.Test
                 .Map(x => x.Name, 10, 10)
                 .Map(x => x.Mother.BirthDay, 20, 10)
                 .Map(x => x.Mother.Name, 30, 12)
-                .Build();
+                .BuildForUnitTest();
 
             var result = reader.Parse("2020.05.23 son name 1980.01.15 mother name");
 
@@ -169,6 +170,12 @@ namespace RecordParser.Test
 
     public static class FixedLengthCustomExtensions
     {
+        public static IFixedLengthReader<T> BuildForUnitTest<T>(this IFixedLengthReaderBuilder<T> source)
+            => source.Build(CultureInfo.InvariantCulture);
+
+        public static IFixedLengthReader<T> BuildForUnitTest<T>(this IFixedLengthReaderSequentialBuilder<T> source)
+            => source.Build(CultureInfo.InvariantCulture);
+
         public static IFixedLengthReaderBuilder<T> MyMap<T>(
             this IFixedLengthReaderBuilder<T> source,
             Expression<Func<T, DateTime>> ex, int startIndex, int length,
@@ -202,7 +209,7 @@ namespace RecordParser.Test
         public static IFixedLengthReader<T> MyBuild<T>(this IFixedLengthReaderBuilder<T> source)
         {
             return source.DefaultTypeConvert(value => value.ToLower())
-                         .Build();
+                         .BuildForUnitTest();
         }
     }
 }

--- a/RecordParser.Test/FixedLengthReaderBuilderTest.cs
+++ b/RecordParser.Test/FixedLengthReaderBuilderTest.cs
@@ -166,6 +166,45 @@ namespace RecordParser.Test
                 }
             });
         }
+
+        [Theory]
+        [InlineData("pt-BR")]
+        [InlineData("en-US")]
+        [InlineData("fr-FR")]
+        [InlineData("ru-RU")]
+        [InlineData("es-ES")]
+        public void Builder_should_use_passed_cultureinfo_to_parse_record(string cultureName)
+        {
+            var culture = new CultureInfo(cultureName);
+
+            var expected = (Name: "foo bar baz",
+                            Birthday: new DateTime(2020, 05, 23),
+                            Money: 123.45M,
+                            Color: Color.LightBlue);
+
+            const int length = 25;
+
+            var reader = new FixedLengthReaderBuilder<(string Name, DateTime Birthday, decimal Money, Color Color)>()
+                 .Map(x => x.Name, 0, length)
+                 .Map(x => x.Birthday, 25, length)
+                 .Map(x => x.Money, 50, length)
+                 .Map(x => x.Color, 75, length)
+                 .Build(culture);
+
+            var values = new[]
+            {
+                expected.Name.ToString(culture).PadRight(length),
+                expected.Birthday.ToString(culture).PadRight(length),
+                expected.Money.ToString(culture).PadRight(length),
+                expected.Color.ToString().PadRight(length),
+            };
+
+            var line = string.Join(string.Empty, values);
+
+            var result = reader.Parse(line);
+
+            result.Should().BeEquivalentTo(expected);
+        }
     }
 
     public static class FixedLengthCustomExtensions

--- a/RecordParser.Test/FixedLengthReaderSequentialBuilderTest.cs
+++ b/RecordParser.Test/FixedLengthReaderSequentialBuilderTest.cs
@@ -17,7 +17,7 @@ namespace RecordParser.Test
                 .Map(x => x.Birthday, 10)
                 .Skip(1)
                 .Map(x => x.Money, 7)
-                .Build();
+                .BuildForUnitTest();
 
             var result = reader.Parse("foo bar baz 2020.05.23 0123.45");
 
@@ -37,7 +37,7 @@ namespace RecordParser.Test
                 .Map(x => x.Debit, 5)
                 .DefaultTypeConvert(value => decimal.Parse(value) / 100)
                 .DefaultTypeConvert(value => DateTime.ParseExact(value, "ddMMyyyy", null))
-                .Build();
+                .BuildForUnitTest();
 
             var result = reader.Parse("012345678901 23052020 12345");
 
@@ -55,7 +55,7 @@ namespace RecordParser.Test
                 .Skip(1)
                 .Map(x => x.Money, 7)
                 .Map(x => x.Nickname, 8, value => value.Slice(0, 4).ToString())
-                .Build();
+                .BuildForUnitTest();
 
             var result = reader.Parse("foo bar baz 23052020 012345 nickname");
 
@@ -73,7 +73,7 @@ namespace RecordParser.Test
                 .Map(x => x.MotherAge, 4)
                 .Map(x => x.FatherAge, 4)
                 .DefaultTypeConvert(value => int.Parse(value) + 2)
-                .Build();
+                .BuildForUnitTest();
 
             var result = reader.Parse(" 15  40  50 ");
 
@@ -89,7 +89,7 @@ namespace RecordParser.Test
                 .Map(x => x.Foo, 4)
                 .Map(x => x.Bar, 4)
                 .Map(x => x.Baz, 4)
-                .Build();
+                .BuildForUnitTest();
 
             var result = reader.Parse(" foo bar baz ");
 

--- a/RecordParser.Test/VariableLengthReaderBuilderTest.cs
+++ b/RecordParser.Test/VariableLengthReaderBuilderTest.cs
@@ -176,6 +176,43 @@ namespace RecordParser.Test
         [InlineData("fr-FR")]
         [InlineData("ru-RU")]
         [InlineData("es-ES")]
+        public void Builder_should_use_passed_cultureinfo_to_parse_record(string cultureName)
+        {
+            var culture = new CultureInfo(cultureName);
+
+            var expected = (Name: "foo bar baz",
+                            Birthday: new DateTime(2020, 05, 23),
+                            Money: 123.45M,
+                            Color: Color.LightBlue);
+
+            var reader = new VariableLengthReaderBuilder<(string Name, DateTime Birthday, decimal Money, Color Color)>()
+                 .Map(x => x.Name, 0)
+                 .Map(x => x.Birthday, 1)
+                 .Map(x => x.Money, 2)
+                 .Map(x => x.Color, 3)
+                 .Build(";", culture);
+
+            var values = new[]
+            {
+                expected.Name.ToString(culture),
+                expected.Birthday.ToString(culture),
+                expected.Money.ToString(culture),
+                expected.Color.ToString(),
+            };
+
+            var line = string.Join(';', values.Select(x => $"  {x}  "));
+
+            var result = reader.Parse(line);
+
+            result.Should().BeEquivalentTo(expected);
+        }
+
+        [Theory]
+        [InlineData("pt-BR")]
+        [InlineData("en-US")]
+        [InlineData("fr-FR")]
+        [InlineData("ru-RU")]
+        [InlineData("es-ES")]
         public void Registered_primitives_types_should_have_default_converters_which_uses_current_cultureinfo(string cultureName)
         {
             var expected = new AllType

--- a/RecordParser.Test/VariableLengthReaderBuilderTest.cs
+++ b/RecordParser.Test/VariableLengthReaderBuilderTest.cs
@@ -18,7 +18,7 @@ namespace RecordParser.Test
                 .Map(x => x.Birthday, 1)
                 .Map(x => x.Money, 2)
                 .Map(x => x.Color, 3)
-                .Build(";");
+                .BuildForUnitTest();
 
             var result = reader.Parse("foo bar baz ; 2020.05.23 ; 0123.45; LightBlue");
 
@@ -37,7 +37,7 @@ namespace RecordParser.Test
                 .Map(x => x.Debit, 2)
                 .DefaultTypeConvert(value => decimal.Parse(value) / 100)
                 .DefaultTypeConvert(value => DateTime.ParseExact(value, "ddMMyyyy", null))
-                .Build(";");
+                .BuildForUnitTest();
 
             var result = reader.Parse("012345678901 ; 23052020 ; 012345");
 
@@ -54,7 +54,7 @@ namespace RecordParser.Test
                 .Map(x => x.Birthday, 1, value => DateTime.ParseExact(value, "ddMMyyyy", null))
                 .Map(x => x.Money, 2)
                 .Map(x => x.Nickname, 3, value => value.Slice(0, 4).ToString())
-                .Build(";");
+                .BuildForUnitTest();
 
             var result = reader.Parse("foo bar baz ; 23052020 ; 012345 ; nickname");
 
@@ -72,7 +72,7 @@ namespace RecordParser.Test
                 .Map(x => x.MotherAge, 1)
                 .Map(x => x.FatherAge, 2)
                 .DefaultTypeConvert(value => int.Parse(value) + 2)
-                .Build(";");
+                .BuildForUnitTest();
 
             var result = reader.Parse(" 15 ; 40 ; 50 ");
 
@@ -104,7 +104,7 @@ namespace RecordParser.Test
                 .Map(x => x.Foo, 0)
                 .Map(x => x.Bar, 1)
                 .Map(x => x.Baz, 2)
-                .Build(";");
+                .BuildForUnitTest();
 
             var result = reader.Parse(" foo ; bar ; baz ");
 
@@ -119,7 +119,7 @@ namespace RecordParser.Test
             var reader = new VariableLengthReaderBuilder<(string Name, DateTime Birthday)>()
                 .Map(x => x.Name, 0)
                 .Map(x => x.Birthday, 1)
-                .Build(";");
+                .BuildForUnitTest();
 
             var parsed = reader.TryParse(" foo ; datehere", out var result);
 
@@ -135,7 +135,7 @@ namespace RecordParser.Test
                 .Map(x => x.Birthday, 1)
                 .Map(x => x.Money, 2)
                 .Map(x => x.Color, 3)
-                .Build(";");
+                .BuildForUnitTest();
 
             var parsed = reader.TryParse("foo bar baz ; 2020.05.23 ; 0123.45; LightBlue", out var result);
 
@@ -154,7 +154,7 @@ namespace RecordParser.Test
                 .Map(x => x.Name, 1)
                 .Map(x => x.Mother.BirthDay, 2)
                 .Map(x => x.Mother.Name, 3)
-                .Build(";");
+                .BuildForUnitTest();
 
             var result = reader.Parse("2020.05.23 ; son name ; 1980.01.15 ; mother name");
 
@@ -170,8 +170,13 @@ namespace RecordParser.Test
             });
         }
 
-        [Fact]
-        public void Registered_primitives_types_should_have_default_converters()
+        [Theory]
+        [InlineData("pt-BR")]
+        [InlineData("en-US")]
+        [InlineData("fr-FR")]
+        [InlineData("ru-RU")]
+        [InlineData("es-ES")]
+        public void Registered_primitives_types_should_have_default_converters_which_uses_current_cultureinfo(string cultureName)
         {
             var expected = new AllType
             {
@@ -194,7 +199,7 @@ namespace RecordParser.Test
                 UShort = 8,
 
                 Guid = new Guid("e808927a-48f9-4402-ab2b-400bf1658169"),
-                Date = DateTime.Today,
+                Date = DateTime.Parse(DateTime.Now.ToString()),
 
                 Bool = true,
                 Decimal = -1.99M,
@@ -254,7 +259,7 @@ namespace RecordParser.Test
                 expected.Decimal,
             };
 
-            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+            CultureInfo.CurrentCulture = new CultureInfo(cultureName);
             var line = string.Join(';', values.Select(x => $"  {x}  "));
 
             var result = reader.Parse(line);
@@ -272,7 +277,7 @@ namespace RecordParser.Test
         {
             var reader = new VariableLengthReaderBuilder<(Color color, bool _)>()
                 .Map(x => x.color, 0)
-                .Build(";");
+                .BuildForUnitTest();
 
             // text as is
             reader.Parse("Black").color.Should().Be(Color.Black);
@@ -301,6 +306,12 @@ namespace RecordParser.Test
 
     public static class VariableLengthReaderCustomExtensions
     {
+        public static IVariableLengthReader<T> BuildForUnitTest<T>(this IVariableLengthReaderBuilder<T> source)
+            => source.Build(";", CultureInfo.InvariantCulture);
+
+        public static IVariableLengthReader<T> BuildForUnitTest<T>(this IVariableLengthReaderSequentialBuilder<T> source)
+            => source.Build(";", CultureInfo.InvariantCulture);
+
         public static IVariableLengthReaderBuilder<T> MyMap<T>(
             this IVariableLengthReaderBuilder<T> source,
             Expression<Func<T, DateTime>> ex, int startIndex,
@@ -312,7 +323,7 @@ namespace RecordParser.Test
         public static IVariableLengthReader<T> MyBuild<T>(this IVariableLengthReaderBuilder<T> source)
         {
             return source.DefaultTypeConvert(value => value.ToLower())
-                         .Build(";");
+                         .BuildForUnitTest();
         }
     }
 }

--- a/RecordParser.Test/VariableLengthReaderSequentialBuilderTest.cs
+++ b/RecordParser.Test/VariableLengthReaderSequentialBuilderTest.cs
@@ -16,7 +16,7 @@ namespace RecordParser.Test
                 .Map(x => x.Name)
                 .Map(x => x.Birthday)
                 .Map(x => x.Money)
-                .Build(";");
+                .BuildForUnitTest();
 
             var result = reader.Parse("foo bar baz ; 2020.05.23 ; 0123.45");
 
@@ -34,7 +34,7 @@ namespace RecordParser.Test
                 .Map(x => x.Birthday)
                 .Skip(2)
                 .Map(x => x.Money)
-                .Build(";");
+                .BuildForUnitTest();
 
             var result = reader.Parse("foo bar baz ; IGNORE; 2020.05.23 ; IGNORE ; IGNORE ; 0123.45");
 
@@ -52,7 +52,7 @@ namespace RecordParser.Test
                 .Map(x => x.Debit)
                 .DefaultTypeConvert(value => decimal.Parse(value) / 100)
                 .DefaultTypeConvert(value => DateTime.ParseExact(value, "ddMMyyyy", null))
-                .Build(";");
+                .BuildForUnitTest();
 
             var result = reader.Parse("012345678901 ; 23052020 ; 012345");
 
@@ -69,7 +69,7 @@ namespace RecordParser.Test
                 .Map(x => x.Birthday, value => DateTime.ParseExact(value, "ddMMyyyy", null))
                 .Map(x => x.Money)
                 .Map(x => x.Nickname, value => value.Slice(0, 4).ToString())
-                .Build(";");
+                .BuildForUnitTest();
 
             var result = reader.Parse("foo bar baz ; 23052020 ; 012345 ; nickname");
 
@@ -87,7 +87,7 @@ namespace RecordParser.Test
                 .Map(x => x.Age, value => int.Parse(value) * 2)
                 .Map(x => x.FatherAge)
                 .DefaultTypeConvert(value => int.Parse(value) + 2)
-                .Build(";");
+                .BuildForUnitTest();
 
             var result = reader.Parse(" 40 ; 15 ; 50 ");
 
@@ -106,7 +106,7 @@ namespace RecordParser.Test
                 .Map(x => x.Age, value => int.Parse(value) * 2)
                 .Map(x => x.FatherAge)
                 .DefaultTypeConvert(value => int.Parse(value) + 2)
-                .Build(";");
+                .BuildForUnitTest();
 
             var result = reader.Parse(" XX ; XX ; 40 ; XX ; 15 ; 50 ; XX");
 
@@ -145,7 +145,7 @@ namespace RecordParser.Test
         public static IVariableLengthReader<T> MyBuild<T>(this IVariableLengthReaderSequentialBuilder<T> source)
         {
             return source.DefaultTypeConvert(value => value.ToLower())
-                         .Build(";");
+                         .BuildForUnitTest();
         }
     }
 }

--- a/RecordParser/Builders/FixedLengthReaderBuilder.cs
+++ b/RecordParser/Builders/FixedLengthReaderBuilder.cs
@@ -1,13 +1,15 @@
 ﻿using RecordParser.Generic;
+using RecordParser.Visitors;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq.Expressions;
 
 namespace RecordParser.Parsers
 {
     public interface IFixedLengthReaderBuilder<T>
     {
-        IFixedLengthReader<T> Build();
+        IFixedLengthReader<T> Build(CultureInfo cultureInfo = null);
         IFixedLengthReaderBuilder<T> DefaultTypeConvert<R>(FuncSpanT<R> ex);
         IFixedLengthReaderBuilder<T> Map<R>(Expression<Func<T, R>> ex, int startIndex, int length, FuncSpanT<R> convert = null);
     }
@@ -32,12 +34,14 @@ namespace RecordParser.Parsers
             return this;
         }
 
-        public IFixedLengthReader<T> Build() 
+        public IFixedLengthReader<T> Build(CultureInfo cultureInfo = null) 
         {
             var map = GenericRecordParser.Merge(list, dic);
-            var func = SpanExpressionParser.RecordParserSpan<T>(map).Compile();
+            var func = SpanExpressionParser.RecordParserSpan<T>(map);
 
-            return new FixedLengthReader<T>(map, func);
+            func = CultureInfoVisitor.ReplaceCulture(func, cultureInfo);
+
+            return new FixedLengthReader<T>(map, func.Compile());
         }
     }
 }

--- a/RecordParser/Builders/FixedLengthReaderSequentialBuilder.cs
+++ b/RecordParser/Builders/FixedLengthReaderSequentialBuilder.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq.Expressions;
 
 namespace RecordParser.Parsers
 {
     public interface IFixedLengthReaderSequentialBuilder<T>
     {
-        IFixedLengthReader<T> Build();
+        IFixedLengthReader<T> Build(CultureInfo cultureInfo = null);
         IFixedLengthReaderSequentialBuilder<T> DefaultTypeConvert<R>(FuncSpanT<R> ex);
         IFixedLengthReaderSequentialBuilder<T> Skip(int length);
         IFixedLengthReaderSequentialBuilder<T> Map<R>(Expression<Func<T, R>> ex, int length, FuncSpanT<R> convert = null);
@@ -37,6 +38,7 @@ namespace RecordParser.Parsers
             return this;
         }
 
-        public IFixedLengthReader<T> Build() =>  indexed.Build();
+        public IFixedLengthReader<T> Build(CultureInfo cultureInfo = null) 
+            => indexed.Build(cultureInfo);
     }
 }

--- a/RecordParser/Builders/VariableLengthReaderBuilder.cs
+++ b/RecordParser/Builders/VariableLengthReaderBuilder.cs
@@ -1,6 +1,8 @@
 ﻿using RecordParser.Generic;
+using RecordParser.Visitors;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 
@@ -8,7 +10,7 @@ namespace RecordParser.Parsers
 {
     public interface IVariableLengthReaderBuilder<T>
     {
-        IVariableLengthReader<T> Build(string separator);
+        IVariableLengthReader<T> Build(string separator, CultureInfo cultureInfo = null);
         IVariableLengthReaderBuilder<T> DefaultTypeConvert<R>(FuncSpanT<R> ex);
         IVariableLengthReaderBuilder<T> Map<R>(Expression<Func<T, R>> ex, int indexColumn, FuncSpanT<R> convert = null);
     }
@@ -33,12 +35,14 @@ namespace RecordParser.Parsers
             return this;
         }
 
-        public IVariableLengthReader<T> Build(string separator)
+        public IVariableLengthReader<T> Build(string separator, CultureInfo cultureInfo = null)
         {
             var map = GenericRecordParser.Merge(list.Select(x => x.Value), dic);
-            var func = SpanExpressionParser.RecordParserSpan<T>(map).Compile();
+            var func = SpanExpressionParser.RecordParserSpan<T>(map);
 
-            return new VariableLengthReader<T>(map, func, separator);
+            func = CultureInfoVisitor.ReplaceCulture(func, cultureInfo);
+
+            return new VariableLengthReader<T>(map, func.Compile(), separator);
         }
     }
 }

--- a/RecordParser/Builders/VariableLengthReaderSequentialBuilder.cs
+++ b/RecordParser/Builders/VariableLengthReaderSequentialBuilder.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq.Expressions;
 
 namespace RecordParser.Parsers
 {
     public interface IVariableLengthReaderSequentialBuilder<T>
     {
-        IVariableLengthReader<T> Build(string separator);
+        IVariableLengthReader<T> Build(string separator, CultureInfo cultureInfo = null);
         IVariableLengthReaderSequentialBuilder<T> DefaultTypeConvert<R>(FuncSpanT<R> ex);
         IVariableLengthReaderSequentialBuilder<T> Map<R>(Expression<Func<T, R>> ex, FuncSpanT<R> convert = null);
         IVariableLengthReaderSequentialBuilder<T> Skip(int columnCount);
@@ -36,6 +37,7 @@ namespace RecordParser.Parsers
             return this;
         }
 
-        public IVariableLengthReader<T> Build(string separator) => indexed.Build(separator);
+        public IVariableLengthReader<T> Build(string separator, CultureInfo cultureInfo = null) 
+            => indexed.Build(separator, cultureInfo);
     }
 }

--- a/RecordParser/Generic/GenericRecordParser.cs
+++ b/RecordParser/Generic/GenericRecordParser.cs
@@ -88,26 +88,26 @@ namespace RecordParser.Generic
             mapping.AddMapForReadOnlySpan(span => new string(span));
             mapping.AddMapForReadOnlySpan(span => ToChar(span));
 
-            mapping.AddMapForReadOnlySpan(span => byte.Parse(span, NumberStyles.Integer, CultureInfo.InvariantCulture));
-            mapping.AddMapForReadOnlySpan(span => sbyte.Parse(span, NumberStyles.Integer, CultureInfo.InvariantCulture));
+            mapping.AddMapForReadOnlySpan(span => byte.Parse(span, NumberStyles.Integer, null));
+            mapping.AddMapForReadOnlySpan(span => sbyte.Parse(span, NumberStyles.Integer, null));
 
-            mapping.AddMapForReadOnlySpan(span => double.Parse(span, NumberStyles.AllowThousands | NumberStyles.Float, CultureInfo.InvariantCulture));
-            mapping.AddMapForReadOnlySpan(span => float.Parse(span, NumberStyles.AllowThousands | NumberStyles.Float, CultureInfo.InvariantCulture));
+            mapping.AddMapForReadOnlySpan(span => double.Parse(span, NumberStyles.AllowThousands | NumberStyles.Float, null));
+            mapping.AddMapForReadOnlySpan(span => float.Parse(span, NumberStyles.AllowThousands | NumberStyles.Float, null));
 
-            mapping.AddMapForReadOnlySpan(span => int.Parse(span, NumberStyles.Integer, CultureInfo.InvariantCulture));
-            mapping.AddMapForReadOnlySpan(span => uint.Parse(span, NumberStyles.Integer, CultureInfo.InvariantCulture));
+            mapping.AddMapForReadOnlySpan(span => int.Parse(span, NumberStyles.Integer, null));
+            mapping.AddMapForReadOnlySpan(span => uint.Parse(span, NumberStyles.Integer, null));
 
-            mapping.AddMapForReadOnlySpan(span => long.Parse(span, NumberStyles.Integer, CultureInfo.InvariantCulture));
-            mapping.AddMapForReadOnlySpan(span => ulong.Parse(span, NumberStyles.Integer, CultureInfo.InvariantCulture));
+            mapping.AddMapForReadOnlySpan(span => long.Parse(span, NumberStyles.Integer, null));
+            mapping.AddMapForReadOnlySpan(span => ulong.Parse(span, NumberStyles.Integer, null));
 
-            mapping.AddMapForReadOnlySpan(span => short.Parse(span, NumberStyles.Integer, CultureInfo.InvariantCulture));
-            mapping.AddMapForReadOnlySpan(span => ushort.Parse(span, NumberStyles.Integer, CultureInfo.InvariantCulture));
+            mapping.AddMapForReadOnlySpan(span => short.Parse(span, NumberStyles.Integer, null));
+            mapping.AddMapForReadOnlySpan(span => ushort.Parse(span, NumberStyles.Integer, null));
 
             mapping.AddMapForReadOnlySpan(span => Guid.Parse(span));
-            mapping.AddMapForReadOnlySpan(span => DateTime.Parse(span, CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces));
+            mapping.AddMapForReadOnlySpan(span => DateTime.Parse(span, null, DateTimeStyles.AllowWhiteSpaces));
 
             mapping.AddMapForReadOnlySpan(span => bool.Parse(span));
-            mapping.AddMapForReadOnlySpan(span => decimal.Parse(span, NumberStyles.Number, CultureInfo.InvariantCulture));
+            mapping.AddMapForReadOnlySpan(span => decimal.Parse(span, NumberStyles.Number, null));
 
             mapping[(typeof(ReadOnlySpan<char>), typeof(Enum))] = GetEnumFromSpanParseExpression;
 

--- a/RecordParser/Visitors/CultureInfoVisitor.cs
+++ b/RecordParser/Visitors/CultureInfoVisitor.cs
@@ -10,7 +10,7 @@ namespace RecordParser.Visitors
 
         public CultureInfoVisitor(CultureInfo cultureInfo)
         {
-            cultureExpression = Expression.Constant(cultureInfo);
+            cultureExpression = Expression.Constant(cultureInfo, typeof(CultureInfo));
         }
 
         public static T ReplaceCulture<T>(T expression, CultureInfo cultureInfo)

--- a/RecordParser/Visitors/CultureInfoVisitor.cs
+++ b/RecordParser/Visitors/CultureInfoVisitor.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Globalization;
+using System.Linq.Expressions;
+
+namespace RecordParser.Visitors
+{
+    internal class CultureInfoVisitor : ExpressionVisitor
+    {
+        private readonly ConstantExpression cultureExpression;
+
+        public CultureInfoVisitor(CultureInfo cultureInfo)
+        {
+            cultureExpression = Expression.Constant(cultureInfo);
+        }
+
+        public static T ReplaceCulture<T>(T expression, CultureInfo cultureInfo)
+            where T : Expression
+        {
+            if (cultureInfo == null)
+                return expression;
+
+            return (T) new CultureInfoVisitor(cultureInfo).Visit(expression);
+        }
+
+        protected override Expression VisitConstant(ConstantExpression node)
+        {
+            if (node.Type == typeof(IFormatProvider))
+                return cultureExpression;
+
+            return base.VisitConstant(node);
+        }
+    }
+}


### PR DESCRIPTION
1. default converters pass `null` for `IFormatProvider` (which framework interpret as `CurrentCulture`)
2. adds optional `CultureInfo` parameter in `Build` methods of readers 
3. adds `CultureInfoVisitor` which is used when passed `CultureInfo` is not null to replace default culture
4. adds unit tests to check items 1 and 3