### PR TITLE
Renames Parse method to TryFormat on writers

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ public void Given_value_using_standard_format_should_parse_without_extra_configu
 
     // Act
 
-    var success = writer.Parse(instance, destination, out var charsWritten);
+    var success = writer.TryFormat(instance, destination, out var charsWritten);
 
     // Assert
 
@@ -266,7 +266,7 @@ public void Given_value_using_standard_format_should_parse_without_extra_configu
 
     // Act
 
-    var success = writer.Parse(instance, destination, out var charsWritten);
+    var success = writer.TryFormat(instance, destination, out var charsWritten);
 
     // Assert
 
@@ -307,7 +307,7 @@ public void Given_value_using_standard_format_should_parse_without_extra_configu
 
     // Act
 
-    var success = writer.Parse(instance, destination, out var charsWritten);
+    var success = writer.TryFormat(instance, destination, out var charsWritten);
 
     // Assert
 
@@ -340,7 +340,7 @@ public void Given_value_using_standard_format_should_parse_without_extra_configu
 
     // Act
 
-    var success = writer.Parse(instance, destination, out var charsWritten);
+    var success = writer.TryFormat(instance, destination, out var charsWritten);
 
     // Assert
 
@@ -380,7 +380,7 @@ public void Given_types_with_custom_format_should_allow_define_default_parser_fo
 
     // Act
 
-    var success = writer.Parse(instance, destination, out var charsWritten);
+    var success = writer.TryFormat(instance, destination, out var charsWritten);
 
     // Assert
 
@@ -420,7 +420,7 @@ public void Given_specified_custom_parser_for_member_should_have_priority_over_c
 
     // Act
 
-    var success = writer.Parse(instance, destination, out var charsWritten);
+    var success = writer.TryFormat(instance, destination, out var charsWritten);
 
     // Assert
 

--- a/RecordParser.Benchmark/VariableLengthWriterBenchmark.cs
+++ b/RecordParser.Benchmark/VariableLengthWriterBenchmark.cs
@@ -106,7 +106,7 @@ namespace RecordParser.Benchmark
                 {
                     if (i++ == LimitRecord) return;
 
-                    if (!writer.Parse(person, destination, out charsWritten))
+                    if (!writer.TryFormat(person, destination, out charsWritten))
                         throw new Exception("cannot write object");
 
                     await streamWriter.WriteLineAsync(destination, 0, charsWritten);

--- a/RecordParser.Test/FixedLengthWriterBuilderTest.cs
+++ b/RecordParser.Test/FixedLengthWriterBuilderTest.cs
@@ -31,7 +31,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -79,7 +79,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -105,7 +105,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -136,7 +136,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -171,7 +171,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -206,7 +206,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -240,7 +240,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -281,7 +281,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 

--- a/RecordParser.Test/FixedLengthWriterSequentialBuilderTest.cs
+++ b/RecordParser.Test/FixedLengthWriterSequentialBuilderTest.cs
@@ -34,7 +34,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -85,7 +85,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -112,7 +112,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -144,7 +144,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -181,7 +181,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -218,7 +218,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -252,7 +252,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -296,7 +296,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 

--- a/RecordParser.Test/VariableLengthWriterBuilderTest.cs
+++ b/RecordParser.Test/VariableLengthWriterBuilderTest.cs
@@ -25,7 +25,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -56,7 +56,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -88,7 +88,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -120,7 +120,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -191,7 +191,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -226,7 +226,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -261,7 +261,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -295,7 +295,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -333,7 +333,7 @@ namespace RecordParser.Test
                 var expected = value.ToString();
                 var instance = (value, 0);
 
-                var success = writer.Parse(instance, span, out var charsWritten);
+                var success = writer.TryFormat(instance, span, out var charsWritten);
 
                 success.Should().BeTrue();
                 span.Slice(0, charsWritten).ToString().Should().Be(expected);
@@ -356,7 +356,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -391,7 +391,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 

--- a/RecordParser.Test/VariableLengthWriterSequentialBuilderTest.cs
+++ b/RecordParser.Test/VariableLengthWriterSequentialBuilderTest.cs
@@ -27,7 +27,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -59,7 +59,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -92,7 +92,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -126,7 +126,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -199,7 +199,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -234,7 +234,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -270,7 +270,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -304,7 +304,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -342,7 +342,7 @@ namespace RecordParser.Test
                 var expected = value.ToString();
                 var instance = (value, 0);
 
-                var success = writer.Parse(instance, span, out var charsWritten);
+                var success = writer.TryFormat(instance, span, out var charsWritten);
 
                 success.Should().BeTrue();
                 span.Slice(0, charsWritten).ToString().Should().Be(expected);
@@ -365,7 +365,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -400,7 +400,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 
@@ -515,7 +515,7 @@ namespace RecordParser.Test
 
             // Act
 
-            var success = writer.Parse(instance, destination, out var charsWritten);
+            var success = writer.TryFormat(instance, destination, out var charsWritten);
 
             // Assert
 

--- a/RecordParser/Parsers/FixedLengthWriter.cs
+++ b/RecordParser/Parsers/FixedLengthWriter.cs
@@ -5,6 +5,9 @@ namespace RecordParser.Parsers
     public interface IFixedLengthWriter<T>
     {
         bool TryFormat(T instance, Span<char> destination, out int charsWritten);
+
+        [Obsolete("Method was renamed to TryFormat. Parse will eventually be removed in future release.")]
+        bool Parse(T instance, Span<char> destination, out int charsWritten);
     }
 
     public delegate (bool success, int charsWritten) FuncSpanTIntBool<T>(Span<char> span, T inst);
@@ -17,6 +20,10 @@ namespace RecordParser.Parsers
         {
             this.parse = parse;
         }
+
+        [Obsolete("Method was renamed to TryFormat. Parse will eventually be removed in future release.")]
+        public bool Parse(T instance, Span<char> destination, out int charsWritten) =>
+            TryFormat(instance, destination, out charsWritten);
 
         public bool TryFormat(T instance, Span<char> destination, out int charsWritten)
         {

--- a/RecordParser/Parsers/FixedLengthWriter.cs
+++ b/RecordParser/Parsers/FixedLengthWriter.cs
@@ -4,7 +4,7 @@ namespace RecordParser.Parsers
 {
     public interface IFixedLengthWriter<T>
     {
-        bool Parse(T instance, Span<char> destination, out int charsWritten);
+        bool TryFormat(T instance, Span<char> destination, out int charsWritten);
     }
 
     public delegate (bool success, int charsWritten) FuncSpanTIntBool<T>(Span<char> span, T inst);
@@ -18,7 +18,7 @@ namespace RecordParser.Parsers
             this.parse = parse;
         }
 
-        public bool Parse(T instance, Span<char> destination, out int charsWritten)
+        public bool TryFormat(T instance, Span<char> destination, out int charsWritten)
         {
             var result = parse(destination, instance);
 

--- a/RecordParser/Parsers/VariableLengthWriter.cs
+++ b/RecordParser/Parsers/VariableLengthWriter.cs
@@ -4,7 +4,7 @@ namespace RecordParser.Parsers
 {
     public interface IVariableLengthWriter<T>
     {
-        bool Parse(T instance, Span<char> destination, out int charsWritten);
+        bool TryFormat(T instance, Span<char> destination, out int charsWritten);
     }
 
     internal delegate (bool success, int charsWritten) FuncSpanSpanTInt<T>(Span<char> span, ReadOnlySpan<char> delimiter, T inst);
@@ -20,7 +20,7 @@ namespace RecordParser.Parsers
             this.separator = separator;
         }
 
-        public bool Parse(T instance, Span<char> destination, out int charsWritten)
+        public bool TryFormat(T instance, Span<char> destination, out int charsWritten)
         {
             var result = parse(destination, separator, instance);
 

--- a/RecordParser/Parsers/VariableLengthWriter.cs
+++ b/RecordParser/Parsers/VariableLengthWriter.cs
@@ -5,6 +5,9 @@ namespace RecordParser.Parsers
     public interface IVariableLengthWriter<T>
     {
         bool TryFormat(T instance, Span<char> destination, out int charsWritten);
+
+        [Obsolete("Method was renamed to TryFormat. Parse will eventually be removed in future release.")]
+        bool Parse(T instance, Span<char> destination, out int charsWritten);
     }
 
     internal delegate (bool success, int charsWritten) FuncSpanSpanTInt<T>(Span<char> span, ReadOnlySpan<char> delimiter, T inst);
@@ -19,6 +22,10 @@ namespace RecordParser.Parsers
             this.parse = parse;
             this.separator = separator;
         }
+
+        [Obsolete("Method was renamed to TryFormat. Parse will eventually be removed in future release.")]
+        public bool Parse(T instance, Span<char> destination, out int charsWritten) =>
+            TryFormat(instance, destination, out charsWritten);
 
         public bool TryFormat(T instance, Span<char> destination, out int charsWritten)
         {


### PR DESCRIPTION
to parse text into other type the framework methods are `Parse` and `TryParse` (ex: `int.Parse`, `int.TryParse`),  
:heavy_check_mark: recordparser readers follow this pattern.

to write some type as text into span the framework method is `TryFormat` (ex. `int.TryFormat`, `DateTime.TryFormat`).  
:x: recordparser writer does not follow this pattern.

:trophy: to be consistent with framework we should rename `Parse` method to `TryFormat` on writers.