### PR TITLE
use Enum.Parse and ToString methods as fallback for read/write

### DIFF
--- a/RecordParser.Test/TestTypes.cs
+++ b/RecordParser.Test/TestTypes.cs
@@ -2,7 +2,7 @@
 
 namespace RecordParser.Test
 {
-    internal enum Color
+    public enum Color
     {
         Black,
         White,
@@ -13,6 +13,18 @@ namespace RecordParser.Test
     public enum EmptyEnum
     {
 
+    }
+
+    [Flags]
+    public enum FlaggedEnum
+    {
+        Some = 1,
+
+        Other = 2,
+
+        Another = 4,
+
+        None = 8
     }
 
     internal class Person

--- a/RecordParser.Test/VariableLengthReaderBuilderTest.cs
+++ b/RecordParser.Test/VariableLengthReaderBuilderTest.cs
@@ -275,9 +275,10 @@ namespace RecordParser.Test
             reader.Parse("777").Should().Be((Color)777);
 
             // text NOT present in enum
-            Action act = () => reader.Parse("foo");
+            var actualEx = AssertionExtensions.Should(() => reader.Parse("foo")).Throw<ArgumentException>().Which;
+            var expectedEx = AssertionExtensions.Should(() => Enum.Parse<Color>("foo", true)).Throw<ArgumentException>().Which;
 
-            act.Should().Throw<ArgumentException>().WithMessage("value foo not present in enum Color");
+            actualEx.Should().BeEquivalentTo(expectedEx, cfg => cfg.Excluding(x => x.StackTrace));
         }
 
         [Fact]

--- a/RecordParser.Test/VariableLengthReaderBuilderTest.cs
+++ b/RecordParser.Test/VariableLengthReaderBuilderTest.cs
@@ -252,31 +252,52 @@ namespace RecordParser.Test
             result.Should().BeEquivalentTo(expected);
         }
 
-        [Fact]
-        public void Parse_enum_same_way_framework()
+        [Theory]
+        // text as is
+        [InlineData("Black", Color.Black)]
+        // text uppercase
+        [InlineData("WHITE", Color.White)]
+        // text lowercase
+        [InlineData("yellow", Color.Yellow)]
+        // numeric value present in enum
+        [InlineData("3", Color.LightBlue)]
+        // numeric value NOT present in enum
+        [InlineData("777", (Color)777)]
+        public void Parse_enum_same_way_framework(string text, Color expected)
         {
             var reader = new VariableLengthReaderBuilder<Color>()
                 .Map(x => x, 0)
                 .Build(";");
 
-            // text as is
-            reader.Parse("Black").Should().Be(Color.Black);
+            reader.Parse(text).Should().Be(expected);
+        }
 
-            // text uppercase
-            reader.Parse("WHITE").Should().Be(Color.White);
+        [Theory]
+        [InlineData(FlaggedEnum.Some)]
+        [InlineData(FlaggedEnum.Another)]
+        [InlineData(FlaggedEnum.Other | FlaggedEnum.Some)]
+        [InlineData(FlaggedEnum.None | FlaggedEnum.Another)]
+        [InlineData((FlaggedEnum)777)]
+        public void Parse_flag_enum_same_way_framework(FlaggedEnum expected)
+        {
+            var reader = new VariableLengthReaderBuilder<FlaggedEnum>()
+                .Map(x => x, 0)
+                .Build(";");
 
-            // text lowercase
-            reader.Parse("yellow").Should().Be(Color.Yellow);
+            var text = expected.ToString();
 
-            // numeric value present in enum
-            reader.Parse("3").Should().Be(Color.LightBlue);
+            reader.Parse(text).Should().Be(expected);
+        }
 
-            // numeric value NOT present in enum
-            reader.Parse("777").Should().Be((Color)777);
+        [Fact]
+        public void Parse_enum_with_text_not_present_in_enum_should_be_same_way_framework()
+        {
+            var reader = new VariableLengthReaderBuilder<Color>()
+                .Map(x => x, 0)
+                .Build(";");
 
-            // text NOT present in enum
             var actualEx = AssertionExtensions.Should(() => reader.Parse("foo")).Throw<ArgumentException>().Which;
-            var expectedEx = AssertionExtensions.Should(() => Enum.Parse<Color>("foo", true)).Throw<ArgumentException>().Which;
+            var expectedEx = AssertionExtensions.Should(() => Enum.Parse<Color>("foo")).Throw<ArgumentException>().Which;
 
             actualEx.Should().BeEquivalentTo(expectedEx, cfg => cfg.Excluding(x => x.StackTrace));
         }

--- a/RecordParser.Test/VariableLengthWriterBuilderTest.cs
+++ b/RecordParser.Test/VariableLengthWriterBuilderTest.cs
@@ -345,34 +345,60 @@ namespace RecordParser.Test
             called.Should().Be(1);
         }
 
-        [Fact]
-        public void Parse_enum_same_way_framework()
+        [Theory]
+        [InlineData(Color.Black)]
+        [InlineData(Color.White)]
+        [InlineData(Color.Yellow)]
+        [InlineData(Color.LightBlue)]
+        [InlineData((Color)777)]
+        public void Parse_enum_same_way_framework(Color value)
         {
+            // Arrange 
+
             var writer = new VariableLengthWriterBuilder<Color>()
                 .Map(x => x, 0)
                 .Build(";");
 
-            Span<char> destination = stackalloc char[50];
+            var expected = value.ToString();
 
-            // values present in enum
+            Span<char> destination = stackalloc char[expected.Length];
 
-            Assert(Color.Black, destination);
-            Assert(Color.White, destination);
-            Assert(Color.Yellow, destination);
-            Assert(Color.LightBlue, destination);
+            // Act
 
-            // value NOT present in enum
-            Assert((Color)777, destination);
+            var success = writer.TryFormat(value, destination, out var charsWritten);
 
-            void Assert(Color value, Span<char> span)
-            {
-                var expected = value.ToString();
+            // Assert
 
-                var success = writer.TryFormat(value, span, out var charsWritten);
+            success.Should().BeTrue();
+            destination.Slice(0, charsWritten).Should().Be(expected);
+        }
 
-                success.Should().BeTrue();
-                span.Slice(0, charsWritten).Should().Be(expected);
-            }
+        [Theory]
+        [InlineData(FlaggedEnum.Some)]
+        [InlineData(FlaggedEnum.Another)]
+        [InlineData(FlaggedEnum.Other | FlaggedEnum.Some)]
+        [InlineData(FlaggedEnum.None | FlaggedEnum.Another)]
+        [InlineData((FlaggedEnum)777)]
+        public void Parse_flag_enum_same_way_framework(FlaggedEnum value)
+        {
+            // Arrange 
+
+            var writer = new VariableLengthWriterBuilder<FlaggedEnum>()
+                .Map(x => x, 0)
+                .Build(";");
+
+            var expected = value.ToString();
+
+            Span<char> destination = stackalloc char[expected.Length];
+
+            // Act
+
+            var success = writer.TryFormat(value, destination, out var charsWritten);
+
+            // Assert
+
+            success.Should().BeTrue();
+            destination.Slice(0, charsWritten).Should().Be(expected);
         }
 
         [Fact]
@@ -384,10 +410,10 @@ namespace RecordParser.Test
                 .Map(x => x, 0)
                 .Build(";");
 
-            Span<char> destination = stackalloc char[50];
-
             var instance = (EmptyEnum)777;
             var expected = instance.ToString();
+
+            Span<char> destination = stackalloc char[expected.Length];
 
             // Act
 

--- a/RecordParser/Engines/ExpressionHelper.cs
+++ b/RecordParser/Engines/ExpressionHelper.cs
@@ -11,6 +11,9 @@ namespace RecordParser.Engines
         public static Expression StringAsSpan(Expression str) =>
             Expression.Call(typeof(MemoryExtensions), "AsSpan", Type.EmptyTypes, str);
 
+        public static Expression SpanAsString(Expression span) =>
+            Expression.Call(span, "ToString", Type.EmptyTypes);
+
         public static Expression Trim(Expression str) =>
             Expression.Call(typeof(MemoryExtensions), "Trim", Type.EmptyTypes, str);
 

--- a/RecordParser/Engines/Reader/PrimitiveTypeReaderEngine.cs
+++ b/RecordParser/Engines/Reader/PrimitiveTypeReaderEngine.cs
@@ -95,15 +95,7 @@ namespace RecordParser.Engines.Reader
                 .Aggregate((Expression)Expression.Condition(
                         Expression.Call(under, "TryParse", Type.EmptyTypes, trim, number),
                         Expression.Convert(number, type),
-                        Expression.Throw(
-                            Expression.New(
-                                typeof(ArgumentException).GetConstructor(new[] { typeof(string) }),
-                                Expression.Call(typeof(string), "Format", Type.EmptyTypes,
-                                    Expression.Constant($"value {{0}} not present in enum {type.Name}"),
-                                    Expression.Call(trim, "ToString", Type.EmptyTypes)
-
-                            )), type)),
-
+                        Expression.Call(typeof(Enum), "Parse", new[] { type }, SpanAsString(trim), Expression.Constant(true))),
                             (acc, item) =>
                                 Expression.Condition(
                                     item.condition,


### PR DESCRIPTION
when enum is not  a "simple" value in enum...

reading
- before: throw exception 
- after: call `Enum.Parse` of .NET

writing
- before: format/serialize value as interger
- after: call `ToString` of .NET

this way we guarantee that for weird/corner cases everything still works as expected while maintaining code still optimized for "simple" values of enum (most common use). 