### PR TITLE
Add Cursively to the benchmark.

### DIFF
--- a/RecordParser.Benchmark/CursivelyPersonVisitor.cs
+++ b/RecordParser.Benchmark/CursivelyPersonVisitor.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Buffers.Text;
+using System.Text;
+
+using Cursively;
+
+namespace RecordParser.Benchmark
+{
+    public delegate void VisitPersonCallback(in Person person);
+
+    public sealed class CursivelyPersonVisitor : CsvReaderVisitorBase
+    {
+        private readonly VisitPersonCallback _callback;
+
+        private int _fieldIndex;
+
+        private byte[] _dataBuf = new byte[1024];
+
+        private int _dataBufUsed;
+
+        private Person _person;
+
+#if NET6_0_OR_GREATER
+        private static readonly int MaxValidGenderLength = GetMaxEnumNameLength<Gender>();
+
+        private readonly char[] _genderBuf = new char[MaxValidGenderLength];
+        
+        private static int GetMaxEnumNameLength<TEnum>() where TEnum : Enum
+        {
+            int maxSoFar = 0;
+            foreach (string name in Enum.GetNames(typeof(TEnum)))
+            {
+                maxSoFar = Math.Max(maxSoFar, name.Length);
+            }
+
+            return maxSoFar;
+        }
+#endif
+
+        public CursivelyPersonVisitor(VisitPersonCallback callback)
+        {
+            _callback = callback;
+        }
+
+        public override void VisitEndOfField(ReadOnlySpan<byte> chunk)
+        {
+            if (_dataBufUsed != 0)
+            {
+                VisitPartialFieldContents(chunk);
+                chunk = _dataBuf.AsSpan(.._dataBufUsed);
+                _dataBufUsed = 0;
+            }
+
+            switch (_fieldIndex++)
+            {
+                case 0:
+                    _ = Utf8Parser.TryParse(chunk, out Guid g, out _);
+                    _person.id = g;
+                    break;
+
+                case 1:
+                    _person.name = Encoding.UTF8.GetString(chunk);
+                    break;
+
+                case 2:
+                    _ = Utf8Parser.TryParse(chunk, out _person.age, out _);
+                    break;
+
+                case 3:
+                    _ = Utf8Parser.TryParse(chunk, out _person.birthday, out _);
+                    break;
+
+                case 4:
+#if NET6_0_OR_GREATER
+                    Span<char> genderChars = _genderBuf.AsSpan(..Encoding.UTF8.GetChars(chunk, _genderBuf));
+                    _person.gender = Enum.Parse<Gender>(genderChars);
+#else
+                    // N.B.: there are ways to improve the efficiency of this for earlier
+                    // targets, but I think it's fine for performance-sensitive applications to
+                    // have to upgrade to .NET 6.0 or higher...
+                    _person.gender = Enum.Parse<Gender>(Encoding.UTF8.GetString(chunk));
+#endif
+                    break;
+
+                case 5:
+                    _person.email = Encoding.UTF8.GetString(chunk);
+                    break;
+
+                case 7:
+                    _ = Utf8Parser.TryParse(chunk, out _person.children, out _);
+                    break;
+            }
+        }
+
+        public override void VisitEndOfRecord()
+        {
+            _callback(in _person);
+            _person = default;
+            _fieldIndex = 0;
+        }
+
+        public override void VisitPartialFieldContents(ReadOnlySpan<byte> chunk)
+        {
+            EnsureCapacity(_dataBufUsed + chunk.Length);
+            chunk.CopyTo(_dataBuf.AsSpan(_dataBufUsed..));
+            _dataBufUsed += chunk.Length;
+        }
+
+        private void EnsureCapacity(int neededLength)
+        {
+            if (_dataBuf.Length >= neededLength)
+            {
+                return;
+            }
+
+            int newLength = _dataBuf.Length;
+
+            // assumption: no field is even close to 2 GiB in length.
+            while (newLength < neededLength)
+            {
+                newLength += newLength;
+            }
+
+            Array.Resize(ref _dataBuf, newLength);
+        }
+    }
+}

--- a/RecordParser.Benchmark/RecordParser.Benchmark.csproj
+++ b/RecordParser.Benchmark/RecordParser.Benchmark.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="Cursively" Version="1.2.0" />
     <PackageReference Include="CsvHelper" Version="27.1.0" />
     <PackageReference Include="FlatFiles" Version="4.15.0" />
     <PackageReference Include="SoftCircuits.CsvParser" Version="3.0.0" />


### PR DESCRIPTION
I noticed your activity on joelverhagen/NCsvPerf#45 (once I got pinged).  I've been poking around in people's CSV parser projects every once in a while to see how my Cursively library does in their benchmarks.  Sometimes, I submit a pull request like this.

N.B: I can't quite get your `Read_VariableLength_RecordParser` to run on my machine, as it always throws an exception here: https://github.com/leandromoh/RecordParser/blob/4b233519e9bd2b2461a3dfce20241cc0b2fe94f9/RecordParser/Engines/Reader/TextFindHelper.cs#L41-L42

I'm hoping that you have better luck with it.

Also, this is mostly intended to be run on .NET 6.0, as it relies on the same kind of thing as in #41 (though there's a fallback for when we build on lower frameworks).  There's more that I **COULD** do to optimize the `Gender` parsing code path, but I don't really feel like reimplementing big parts of `Enum.Parse<T>` right now :grinning: