### PR TITLE
improvement/record-too-large-exception

### DIFF
--- a/RecordParser.Test/SpanExtensions.cs
+++ b/RecordParser.Test/SpanExtensions.cs
@@ -22,12 +22,15 @@ namespace RecordParser.Test
         }
 
         // FluentAssertions does not support Span yet
-        public static StringAssertions Should(this Span<char> value)
-            => value.ToString().Should();
+        public static StringAssertions Should(this Span<char> value) =>
+            value.ToString().Should();
 
         // FluentAssertions does not support ReadOnlySpan yet
-        public static StringAssertions Should(this ReadOnlySpan<char> value)
-            => value.ToString().Should();
+        public static StringAssertions Should(this ReadOnlySpan<char> value) =>
+            value.ToString().Should();
+
+        public static AndConstraint<StringAssertions> Be(this StringAssertions value, ReadOnlySpan<char> expected) =>
+            value.Be(expected.ToString());
 
         public static readonly FuncSpanTIntBool ToUpperInvariant = (Span<char> span, ReadOnlySpan<char> text) =>
             (text.ToUpperInvariant(span) is var written && written == text.Length, Math.Max(0, written));

--- a/RecordParser/Extensions/FileReader/RecordTooLargeException.cs
+++ b/RecordParser/Extensions/FileReader/RecordTooLargeException.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace RecordParser.Extensions
+{
+    /// <summary>
+    /// The exception that is thrown when a single record is too large to fit in the read buffer.
+    /// </summary>
+    /// <remarks>
+    /// A possible cause is incorrectly formatted file. 
+    /// At the moment, the library does not support to customize the buffer size.
+    /// </remarks>
+    public class RecordTooLargeException : Exception
+    {
+        public RecordTooLargeException(string Message) : base(Message) { }
+    }
+}

--- a/RecordParser/Extensions/FileReader/RowReaders/RowBy.cs
+++ b/RecordParser/Extensions/FileReader/RowReaders/RowBy.cs
@@ -34,7 +34,7 @@ internal abstract class RowBy : IFL
         if (initial == false)
         {
             if (len == buffer.Length)
-                throw new RecordTooLargeException("Record found is too large.");
+                throw new RecordTooLargeException("Record is too large.");
 
             Array.Copy(buffer, j, buffer, 0, len);
         }

--- a/RecordParser/Extensions/FileReader/RowReaders/RowBy.cs
+++ b/RecordParser/Extensions/FileReader/RowReaders/RowBy.cs
@@ -33,6 +33,9 @@ internal abstract class RowBy : IFL
         var len = i - j;
         if (initial == false)
         {
+            if (len == buffer.Length)
+                throw new RecordTooLargeException("Record found is too large.");
+
             Array.Copy(buffer, j, buffer, 0, len);
         }
 


### PR DESCRIPTION
Before:
- `Exception` 
- wrong message

After:
- `RecordTooLargeException`
- right message