### PR TITLE
bugfix/first-field-quoted

### DIFF
--- a/RecordParser.Test/QuotedFileReaderTest.cs
+++ b/RecordParser.Test/QuotedFileReaderTest.cs
@@ -2,6 +2,7 @@
 using RecordParser.Builders.Reader;
 using RecordParser.Extensions;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -19,11 +20,20 @@ namespace RecordParser.Test
             public Gender Gender;
         }
 
+        public static IEnumerable<object[]> QuotedFieldsAnyColumn()
+        {
+            foreach (var parallel in new[] { true, false })
+            {
+                foreach (var newline in new[] { "\r", "\n", "\r\n" })
+                {
+                    yield return new object[] { parallel, newline };
+                }
+            }
+        }
+
         [Theory]
-        [InlineData("\r")]
-        [InlineData("\n")]
-        [InlineData("\r\n")]
-        public void Given_quoted_field_in_any_column_should_parse_successfully(string newline)
+        [MemberData(nameof(QuotedFieldsAnyColumn))]
+        public void Given_quoted_field_in_any_column_should_parse_successfully(bool parallel, string newline)
         {
             // Arrange
 
@@ -71,8 +81,9 @@ namespace RecordParser.Test
                 Separator = ",",
                 ParallelismOptions = new()
                 {
-                    Enabled = false,
-                    MaxDegreeOfParallelism = 2
+                    Enabled = parallel,
+                    MaxDegreeOfParallelism = 2,
+                    EnsureOriginalOrdering = true,
                 },
             };
 
@@ -80,7 +91,7 @@ namespace RecordParser.Test
 
             var records = reader.ReadRecordsRaw(options, getField =>
             {
-                var record = 
+                var record =
                 (
                     getField(0),
                     getField(1),

--- a/RecordParser.Test/QuotedFileReaderTest.cs
+++ b/RecordParser.Test/QuotedFileReaderTest.cs
@@ -3,6 +3,7 @@ using RecordParser.Builders.Reader;
 using RecordParser.Extensions;
 using System;
 using System.IO;
+using System.Linq;
 using System.Text;
 using Xunit;
 
@@ -16,6 +17,58 @@ namespace RecordParser.Test
             public DateTime Date;
             public string Name;
             public Gender Gender;
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void foo(bool parallel)
+        {
+            // Arrange
+
+            var fileContent = """
+                A,B,C,D
+                "x
+                y",2,3,4
+                """;
+
+            var reader = new StringReader(fileContent);
+            var options = new VariableLengthReaderRawOptions
+            {
+                HasHeader = true,
+                ContainsQuotedFields = true,
+                ColumnCount = 4,
+                Separator = ",",
+                ParallelismOptions = new()
+                {
+                    Enabled = parallel,
+                    MaxDegreeOfParallelism = 2
+                },
+            };
+
+            // Act
+
+            var records = reader.ReadRecordsRaw(options, getField =>
+            {
+                var record = new
+                {
+                    A = getField(0),
+                    B = getField(1),
+                    C = getField(2),
+                    D = getField(3)
+                };
+                return record;
+            }).ToList();
+
+            // Assert
+
+            records.Should().HaveCount(1);
+
+            var record = records.Single();
+            record.A.Should().Be("x\r\ny");
+            record.B.Should().Be("2");
+            record.C.Should().Be("3");
+            record.D.Should().Be("4");
         }
 
         [Theory]

--- a/RecordParser/Extensions/FileReader/RowReaders/RowByQuote.cs
+++ b/RecordParser/Extensions/FileReader/RowReaders/RowByQuote.cs
@@ -58,7 +58,7 @@ namespace RecordParser.Extensions.FileReader.RowReaders
                 else if (c == quote)
                 {
                     ReadOnlySpan<char> span = buffer.AsSpan().Slice(0, i - 1);
-                    var isQuotedField = span.TrimEnd().EndsWith(separator);
+                    var isQuotedField = i == 1 || span[span.Length - 1] == '\n' || span.TrimEnd().EndsWith(separator);
 
                     if (isQuotedField is false)
                         continue;

--- a/RecordParser/Extensions/FileReader/RowReaders/RowByQuote.cs
+++ b/RecordParser/Extensions/FileReader/RowReaders/RowByQuote.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.CompilerServices;
 
 namespace RecordParser.Extensions.FileReader.RowReaders
 {
@@ -58,7 +59,7 @@ namespace RecordParser.Extensions.FileReader.RowReaders
                 else if (c == quote)
                 {
                     ReadOnlySpan<char> span = buffer.AsSpan().Slice(0, i - 1);
-                    var isQuotedField = i == 1 || span[span.Length - 1] == '\n' || span.TrimEnd().EndsWith(separator);
+                    var isQuotedField = IsFirstColumn(span) || span.TrimEnd().EndsWith(separator);
 
                     if (isQuotedField is false)
                         continue;
@@ -102,6 +103,28 @@ namespace RecordParser.Extensions.FileReader.RowReaders
                 yield return y;
 
             goto reloop;
+
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            static bool IsFirstColumn(ReadOnlySpan<char> span)
+            {
+                var onlyWhiteSpace = true;
+
+                for (var i = span.Length - 1; i >= 0; i--)
+                {
+                    if (char.IsWhiteSpace(span[i]))
+                    {
+                        if (span[i] is '\n' or '\r')
+                            return true;
+                        else
+                            continue;
+                    }
+                    onlyWhiteSpace = false;
+                    break;
+                }
+
+                return onlyWhiteSpace;
+            }
         }
     }
 }


### PR DESCRIPTION
currently the library throws when parsing the following:
```
A,B,C,D
"x
y",2,3,4
```

the bug happen only when the first field of the record is a quoted field, when it is not the first field, everything works fine ([dotnetfiddle](https://dotnetfiddle.net/39vMDF))