### PR TITLE
Add .NET Standard 2.0 target

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = unset
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[*.{proj,props,sln,targets,sql}]
+indent_style = tab
+
+[*.{dna,config,nuspec,xml,xsd,csproj,vcxproj,vcproj,targets,ps1,resx}]
+indent_size = 2
+
+[*.{cpp,h,def}]
+indent_style = tab
+
+[*.dotsettings]
+end_of_line = lf
+
+[*.sas]
+indent_style = tab
+end_of_line = lf

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ coverage.xml
 .vscode/
 .idea/
 *.user
+/_ReSharper.Caches/ReSharperPlatformVs17233_c49249f4.RecordParser.00

--- a/RecordParser.Benchmark/Common.cs
+++ b/RecordParser.Benchmark/Common.cs
@@ -58,7 +58,7 @@ namespace RecordParser.Benchmark
 
             if (sequence.IsSingleSegment)
             {
-                return Parse(sequence.FirstSpan, parser);
+                return Parse(sequence.First.Span, parser);
             }
 
             var length = (int)sequence.Length;

--- a/RecordParser.Benchmark/CursivelyPersonVisitor.cs
+++ b/RecordParser.Benchmark/CursivelyPersonVisitor.cs
@@ -33,7 +33,7 @@ namespace RecordParser.Benchmark
             if (_dataBufUsed != 0)
             {
                 VisitPartialFieldContents(chunk);
-                chunk = _dataBuf.AsSpan(.._dataBufUsed);
+                chunk = _dataBuf.AsSpan(0, _dataBufUsed);
                 _dataBufUsed = 0;
             }
 
@@ -55,8 +55,8 @@ namespace RecordParser.Benchmark
                 case 3:
                     // M/d/yyyy format is not supported by this for some reason.
                     ////_ = Utf8Parser.TryParse(chunk, out _person.birthday, out _);
-                    Span<char> birthdayChars = _decodeBuf.AsSpan(..Encoding.UTF8.GetChars(chunk, _decodeBuf));
-                    _person.birthday = DateTime.Parse(birthdayChars, DateTimeFormatInfo.InvariantInfo);
+                    Span<char> birthdayChars = _decodeBuf.AsSpan(0, Encoding.UTF8.GetChars(chunk, _decodeBuf));
+                    _person.birthday = Parse.DateTime(birthdayChars, DateTimeFormatInfo.InvariantInfo);
                     break;
 
                 case 4:
@@ -67,7 +67,7 @@ namespace RecordParser.Benchmark
                     // N.B.: there are ways to improve the efficiency of this for earlier
                     // targets, but I think it's fine for performance-sensitive applications to
                     // have to upgrade to .NET 6.0 or higher...
-                    _person.gender = Enum.Parse<Gender>(Encoding.UTF8.GetString(chunk));
+                    _person.gender = Parse.Enum<Gender>(Encoding.UTF8.GetString(chunk).AsSpan());
 #endif
                     break;
 
@@ -91,7 +91,7 @@ namespace RecordParser.Benchmark
         public override void VisitPartialFieldContents(ReadOnlySpan<byte> chunk)
         {
             EnsureCapacity(_dataBufUsed + chunk.Length);
-            chunk.CopyTo(_dataBuf.AsSpan(_dataBufUsed..));
+            chunk.CopyTo(_dataBuf.AsSpan(_dataBufUsed));
             _dataBufUsed += chunk.Length;
         }
 

--- a/RecordParser.Benchmark/FixedLengthReaderBenchmark.cs
+++ b/RecordParser.Benchmark/FixedLengthReaderBenchmark.cs
@@ -44,7 +44,7 @@ namespace RecordParser.Benchmark
                     name = line.Substring(2, 30).Trim(),
                     age = int.Parse(line.Substring(32, 2)),
                     birthday = DateTime.Parse(line.Substring(39, 10), CultureInfo.InvariantCulture),
-                    gender = Enum.Parse<Gender>(line.Substring(85, 6)),
+                    gender = Parse.Enum<Gender>(line.Substring(85, 6).AsSpan()),
                     email = line.Substring(92, 22).Trim(),
                     children = bool.Parse(line.Substring(121, 5))
                 };
@@ -151,12 +151,12 @@ namespace RecordParser.Benchmark
                 return new Person
                 {
                     alfa = line[0],
-                    name = new string(line.Slice(2, 30).Trim()),
-                    age = int.Parse(line.Slice(32, 2)),
-                    birthday = DateTime.Parse(line.Slice(39, 10), CultureInfo.InvariantCulture),
-                    gender = Enum.Parse<Gender>(line.Slice(85, 6)),
-                    email = new string(line.Slice(92, 22).Trim()),
-                    children = bool.Parse(line.Slice(121, 5))
+                    name = line.Slice(2, 30).Trim().ToString(),
+                    age = Parse.Int32(line.Slice(32, 2)),
+                    birthday = Parse.DateTime(line.Slice(39, 10), CultureInfo.InvariantCulture),
+                    gender = Parse.Enum<Gender>(line.Slice(85, 6)),
+                    email = line.Slice(92, 22).Trim().ToString(),
+                    children = Parse.Boolean(line.Slice(121, 5))
                 };
             });
 

--- a/RecordParser.Benchmark/Parse.cs
+++ b/RecordParser.Benchmark/Parse.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+
+namespace RecordParser.Benchmark
+{
+    internal static class Parse
+    {
+#if NETSTANDARD2_0 || NETFRAMEWORK
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static string ProcessSpan(ReadOnlySpan<char> span) => span.ToString();
+#else
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ReadOnlySpan<char> ProcessSpan(ReadOnlySpan<char> span) => span;
+#endif
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static byte Byte(ReadOnlySpan<char> utf8Text, IFormatProvider provider = null) => byte.Parse(ProcessSpan(utf8Text), NumberStyles.Integer, provider);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static sbyte SByte(ReadOnlySpan<char> utf8Text, IFormatProvider provider = null) => sbyte.Parse(ProcessSpan(utf8Text), NumberStyles.Integer, provider);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Double(ReadOnlySpan<char> utf8Text, IFormatProvider provider = null) => double.Parse(ProcessSpan(utf8Text), NumberStyles.AllowThousands | NumberStyles.Float, provider);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Single(ReadOnlySpan<char> utf8Text, IFormatProvider provider = null) => float.Parse(ProcessSpan(utf8Text), NumberStyles.AllowThousands | NumberStyles.Float, provider);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Int32(ReadOnlySpan<char> utf8Text, IFormatProvider provider = null) => int.Parse(ProcessSpan(utf8Text), NumberStyles.Integer, provider);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Guid Guid(ReadOnlySpan<char> utf8Text) => System.Guid.Parse(ProcessSpan(utf8Text));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static DateTime DateTime(ReadOnlySpan<char> utf8Text, IFormatProvider provider = null) => System.DateTime.Parse(ProcessSpan(utf8Text), provider, DateTimeStyles.AllowWhiteSpaces);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool Boolean(ReadOnlySpan<char> utf8Text) => bool.Parse(ProcessSpan(utf8Text));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TEnum Enum<TEnum>(ReadOnlySpan<char> utf8Text) where TEnum : struct, Enum
+        {
+#if NETSTANDARD2_0 || NETFRAMEWORK
+            return (TEnum)System.Enum.Parse(typeof(TEnum), utf8Text.ToString());
+#elif NETSTANDARD2_1
+            return System.Enum.Parse<TEnum>(utf8Text.ToString());
+#else
+            return System.Enum.Parse<TEnum>(utf8Text);
+#endif
+        }
+    }
+}

--- a/RecordParser.Benchmark/RecordParser.Benchmark.csproj
+++ b/RecordParser.Benchmark/RecordParser.Benchmark.csproj
@@ -2,9 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
 	<!--<DefineConstants>TEST_ALL</DefineConstants>-->
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='net472'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,6 +21,13 @@
     <PackageReference Include="System.IO.Pipelines" Version="7.0.0" />
     <PackageReference Include="TinyCsvParser" Version="2.7.0" />
     <PackageReference Include="ZString" Version="2.5.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net472'">
+    <PackageReference Include="PolySharp" Version="1.14.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/RecordParser.Benchmark/Shims.cs
+++ b/RecordParser.Benchmark/Shims.cs
@@ -1,0 +1,72 @@
+﻿#if NETSTANDARD2_0 || NETFRAMEWORK
+
+using System;
+using System.Buffers;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RecordParser.Benchmark
+{
+    internal static class Shims
+    {
+        public static int GetChars(this Encoding encoding, ReadOnlySpan<byte> bytes, Span<char> chars)
+        {
+            unsafe
+            {
+                fixed (byte* b = &MemoryMarshal.GetReference(bytes))
+                {
+                    int charCount = encoding.GetCharCount(b, bytes.Length);
+                    if (charCount > chars.Length) return 0;
+
+                    fixed (char* c = &MemoryMarshal.GetReference(chars))
+                    {
+                        return encoding.GetChars(b, bytes.Length, c, chars.Length);
+                    }
+                }
+            }
+        }
+
+        public static string GetString(this Encoding encoding, scoped ReadOnlySpan<byte> bytes)
+        {
+            if (bytes.IsEmpty) return string.Empty;
+
+            unsafe
+            {
+                fixed (byte* pB = &MemoryMarshal.GetReference(bytes))
+                {
+                    return encoding.GetString(pB, bytes.Length);
+                }
+            }
+        }
+
+        public static Task WriteLineAsync(this TextWriter writer, ReadOnlyMemory<char> value, CancellationToken cancellationToken = default)
+        {
+            if (MemoryMarshal.TryGetArray(value, out var arraySegment))
+            {
+                return arraySegment.Array is null ? Task.CompletedTask : writer.WriteLineAsync(arraySegment.Array, arraySegment.Offset, arraySegment.Count);
+            }
+
+            return Impl(writer, value);
+
+            static async Task Impl(TextWriter writer, ReadOnlyMemory<char> value)
+            {
+                var pool = ArrayPool<char>.Shared;
+                var array = pool.Rent(value.Length);
+                try
+                {
+                    value.CopyTo(array.AsMemory());
+                    await writer.WriteLineAsync(array, 0, value.Length);
+                }
+                finally
+                {
+                    pool.Return(array);
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/RecordParser.Benchmark/VariableLengthReaderBenchmark.cs
+++ b/RecordParser.Benchmark/VariableLengthReaderBenchmark.cs
@@ -46,14 +46,14 @@ namespace RecordParser.Benchmark
             {
                 if (i++ == LimitRecord) return;
 
-                var coluns = line.Split(",");
+                var coluns = line.Split(',');
                 var person = new Person()
                 {
                     id = Guid.Parse(coluns[0]),
                     name = coluns[1].Trim(),
                     age = int.Parse(coluns[2]),
                     birthday = DateTime.Parse(coluns[3], CultureInfo.InvariantCulture),
-                    gender = Enum.Parse<Gender>(coluns[4]),
+                    gender = Parse.Enum<Gender>(coluns[4].AsSpan()),
                     email = coluns[5].Trim(),
                     children = bool.Parse(coluns[7])
                 };
@@ -203,7 +203,7 @@ namespace RecordParser.Benchmark
                     name = getColumnValue(1).Trim(),
                     age = int.Parse(getColumnValue(2)),
                     birthday = DateTime.Parse(getColumnValue(3), CultureInfo.InvariantCulture),
-                    gender = Enum.Parse<Gender>(getColumnValue(4)),
+                    gender = Parse.Enum<Gender>(getColumnValue(4).AsSpan()),
                     email = getColumnValue(5).Trim(),
                     children = bool.Parse(getColumnValue(7))
                 };
@@ -262,13 +262,13 @@ namespace RecordParser.Benchmark
 
                 return new Person
                 {
-                    id = Guid.Parse(id),
+                    id = Parse.Guid(id),
                     name = name.ToString(),
-                    age = int.Parse(age),
-                    birthday = DateTime.Parse(birthday, DateTimeFormatInfo.InvariantInfo),
-                    gender = Enum.Parse<Gender>(gender),
+                    age = Parse.Int32(age),
+                    birthday = Parse.DateTime(birthday, DateTimeFormatInfo.InvariantInfo),
+                    gender = Parse.Enum<Gender>(gender),
                     email = email.ToString(),
-                    children = bool.Parse(children)
+                    children = Parse.Boolean(children)
                 };
             });
         }

--- a/RecordParser.Benchmark/VariableLengthWriterBenchmark.cs
+++ b/RecordParser.Benchmark/VariableLengthWriterBenchmark.cs
@@ -79,7 +79,7 @@ namespace RecordParser.Benchmark
                     sb.Append(";");
                     sb.Append(person.children);
 
-                    await streamWriter.WriteLineAsync(sb);
+                    await streamWriter.WriteLineAsync(sb.ToString());
                     sb.Clear();
                 }
             }

--- a/RecordParser.Test/FileReaderTest.cs
+++ b/RecordParser.Test/FileReaderTest.cs
@@ -246,7 +246,7 @@ namespace RecordParser.Test
                 new () { id = new Guid("63858071-cbb3-5abd-9f88-3dfd565cc4ab"), name = "Lucy Berry", age = 49, birthday = DateTime.Parse("11/12/1961"), gender = Gender.Female, email = "vanvo@ro.pk", children = false },
                 new () { id = new Guid("203804f9-93e7-5510-8bb2-177296bafe6a"), name = "Frank Fox", age = 36, birthday = DateTime.Parse("3/19/1977"), gender = Gender.Male, email = "vav@ped.fj", children = true },
                 new () { id = new Guid("a8af66fb-bad4-51eb-810c-bf3ca22337c6"), name = "Isabel Todd", age = 51, birthday = DateTime.Parse("9/16/1999"), gender = Gender.Female, email = "gu@or.bz", children = false },
-                new () { id = new Guid("1a3d8a66-3e0c-50eb-99c1-a3926bce15ed"), name = $"Joseph {Environment.NewLine}Scott", age = 55, birthday = DateTime.Parse("10/26/1986"), gender = Gender.Male, email = "bup@vugeb.tt", children = false },
+                new () { id = new Guid("1a3d8a66-3e0c-50eb-99c1-a3926bce15ed"), name = "Joseph \r\nScott", age = 55, birthday = DateTime.Parse("10/26/1986"), gender = Gender.Male, email = "bup@vugeb.tt", children = false },
                 new () { id = new Guid("aa7d4395-f10f-5776-9912-e3d86c4b9d3c"), name = "Gilbert Brooks", age = 56, birthday = DateTime.Parse("3/1/1956"), gender = Gender.Female, email = "epiju@ba.ly", children = true },
                 new () { id = new Guid("1d25b811-4002-5744-ac40-93a50f2a442c"), name = "Louis \"Ronaldo\" Bennett", age = 25, birthday = DateTime.Parse("4/4/1967"), gender = Gender.Male, email = "ma@itrovive.tv", children = true },
                 new () { id = new Guid("8e963ae5-a9ed-5572-b11c-566abc6a8a56"), name = "Norman Parker", age = 57, birthday = DateTime.Parse("4/17/1969"), gender = Gender.Male, email = "omi@hewepa.bw", children = true },
@@ -291,7 +291,7 @@ namespace RecordParser.Test
             var expectedItems = new Quoted[]
             {
                 new Quoted { Id = 1, Date = new DateTime(2010, 01, 02), Name = "Ana", Rate = "Good", Ranking = 56 },
-                new Quoted { Id = 2, Date = new DateTime(2011, 05, 12), Name = "Bob", Rate = $"Much {Environment.NewLine}Good", Ranking = 4 },
+                new Quoted { Id = 2, Date = new DateTime(2011, 05, 12), Name = "Bob", Rate = "Much \r\nGood", Ranking = 4 },
                 new Quoted { Id = 3, Date = new DateTime(2013, 12, 10), Name = "Carla", Rate = "\"Medium\"", Ranking = 5 },
                 new Quoted { Id = 4, Date = new DateTime(2015, 03, 03), Name = "Derik", Rate = "Absolute, Awesome", Ranking = 1 },
             }

--- a/RecordParser.Test/FileWriterTest.cs
+++ b/RecordParser.Test/FileWriterTest.cs
@@ -59,7 +59,7 @@ namespace RecordParser.Test
 
             var reader = new VariableLengthReaderBuilder<(string Name, DateTime Birthday, decimal Money, Color Color, int Index)>()
                 .Map(x => x.Name, 0)
-                .Map(x => x.Birthday, 1, value => new DateTime(long.Parse(value)))
+                .Map(x => x.Birthday, 1, value => new DateTime(Parse.Int64(value)))
                 .Map(x => x.Money, 2)
                 .Map(x => x.Color, 3)
                 .Map(x => x.Index, 4)

--- a/RecordParser.Test/FixedLengthWriterBuilderTest.cs
+++ b/RecordParser.Test/FixedLengthWriterBuilderTest.cs
@@ -1,7 +1,6 @@
 ﻿using AutoFixture;
 using FluentAssertions;
 using RecordParser.Builders.Writer;
-using RecordParser.Test;
 using System;
 using System.Linq;
 using System.Linq.Expressions;
@@ -41,7 +40,7 @@ namespace RecordParser.Test
             success.Should().BeTrue();
             charsWritten.Should().Be(50);
 
-            var expected = string.Join('\0', new[]
+            var expected = string.Join("\0", new[]
             {
                 instance.Name.PadRight(15, ' '),
                 instance.Birthday.ToString("yyyy.MM.dd"),
@@ -156,7 +155,7 @@ namespace RecordParser.Test
                 .Map(x => x.Date, 13, 8)
                 .Map(x => x.Debit, 22, 6, padding: Padding.Left, paddingChar: '0')
                 .DefaultTypeConvert<decimal>((span, value) => (((long)(value * 100)).TryFormat(span, out var written), written))
-                .DefaultTypeConvert<DateTime>((span, value) => (value.TryFormat(span, out var written, "ddMMyyyy"), written))
+                .DefaultTypeConvert<DateTime>((span, value) => (value.TryFormat(span, out var written, "ddMMyyyy".AsSpan()), written))
                 .Build();
 
             var instance = (Balance: 0123456789.01M,
@@ -188,7 +187,7 @@ namespace RecordParser.Test
 
             var writer = new FixedLengthWriterBuilder<(string Name, DateTime Birthday, decimal Money, string Nickname)>()
                 .Map(x => x.Name, 0, 12, (span, text) => (true, text.AsSpan().ToUpperInvariant(span)))
-                .Map(x => x.Birthday, 12, 8, (span, date) => (date.TryFormat(span, out var written, "ddMMyyyy"), written))
+                .Map(x => x.Birthday, 12, 8, (span, date) => (date.TryFormat(span, out var written, "ddMMyyyy".AsSpan()), written))
                 .Map(x => x.Money, 21, 7, padding: Padding.Left, paddingChar: '0')
                 .Map(x => x.Nickname, 29, 8, (span, text) => (true, text.AsSpan().Slice(0, 4).ToUpperInvariant(span)), paddingChar: '-')
                 .Build();
@@ -378,7 +377,7 @@ namespace RecordParser.Test
             var multiply = (int)Math.Pow(10, precision);
 
             return builder.Map(ex, startIndex, length,
-                (span, value) => (((int)(value * multiply)).TryFormat(span, out var written, format), written),
+                (span, value) => (((int)(value * multiply)).TryFormat(span, out var written, format.AsSpan()), written),
                 padding, paddingChar);
         }
     }

--- a/RecordParser.Test/FixedLengthWriterSequentialBuilderTest.cs
+++ b/RecordParser.Test/FixedLengthWriterSequentialBuilderTest.cs
@@ -1,6 +1,5 @@
 ﻿using FluentAssertions;
 using RecordParser.Builders.Writer;
-using RecordParser.Test;
 using System;
 using System.Linq.Expressions;
 using Xunit;
@@ -42,7 +41,7 @@ namespace RecordParser.Test
             success.Should().BeTrue();
             charsWritten.Should().Be(50);
 
-            var expected = string.Join('\0', new[]
+            var expected = string.Join("\0", new[]
             {
                 instance.Name.PadRight(15, ' '),
                 instance.Birthday.ToString("yyyy.MM.dd"),
@@ -164,7 +163,7 @@ namespace RecordParser.Test
                 .Skip(1)
                 .Map(x => x.Debit, 6, padding: Padding.Left, paddingChar: '0')
                 .DefaultTypeConvert<decimal>((span, value) => (((long)(value * 100)).TryFormat(span, out var written), written))
-                .DefaultTypeConvert<DateTime>((span, value) => (value.TryFormat(span, out var written, "ddMMyyyy"), written))
+                .DefaultTypeConvert<DateTime>((span, value) => (value.TryFormat(span, out var written, "ddMMyyyy".AsSpan()), written))
                 .Build();
 
             var instance = (Balance: 0123456789.01M,
@@ -196,7 +195,7 @@ namespace RecordParser.Test
 
             var writer = new FixedLengthWriterSequentialBuilder<(string Name, DateTime Birthday, decimal Money, string Nickname)>()
                 .Map(x => x.Name, 12, (span, text) => (true, text.AsSpan().ToUpperInvariant(span)))
-                .Map(x => x.Birthday, 8, (span, date) => (date.TryFormat(span, out var written, "ddMMyyyy"), written))
+                .Map(x => x.Birthday, 8, (span, date) => (date.TryFormat(span, out var written, "ddMMyyyy".AsSpan()), written))
                 .Skip(2)
                 .Map(x => x.Money, 7, padding: Padding.Left, paddingChar: '0')
                 .Skip(1)
@@ -347,7 +346,7 @@ namespace RecordParser.Test
             var multiply = (int)Math.Pow(10, precision);
 
             return builder.Map(ex, length,
-                (span, value) => (((int)(value * multiply)).TryFormat(span, out var written, format), written),
+                (span, value) => (((int)(value * multiply)).TryFormat(span, out var written, format.AsSpan()), written),
                 padding, paddingChar);
         }
     }

--- a/RecordParser.Test/Format.cs
+++ b/RecordParser.Test/Format.cs
@@ -1,0 +1,53 @@
+﻿#if NETSTANDARD2_0 || NETFRAMEWORK
+
+using System;
+
+namespace RecordParser.Test
+{
+    internal static class Format
+    {
+        public static bool TryFormat(this int @this, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider provider = null)
+        {
+            string value = @this.ToString(format.ToString(), provider);
+            if (value.Length > destination.Length)
+            {
+                charsWritten = 0;
+                return false;
+            }
+
+            charsWritten = value.Length;
+            value.AsSpan().CopyTo(destination);
+            return true;
+        }
+
+        public static bool TryFormat(this long @this, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider provider = null)
+        {
+            string value = @this.ToString(format.ToString(), provider);
+            if (value.Length > destination.Length)
+            {
+                charsWritten = 0;
+                return false;
+            }
+
+            charsWritten = value.Length;
+            value.AsSpan().CopyTo(destination);
+            return true;
+        }
+
+        public static bool TryFormat(this DateTime @this, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider provider = null)
+        {
+            string value = @this.ToString(format.ToString(), provider);
+            if (value.Length > destination.Length)
+            {
+                charsWritten = 0;
+                return false;
+            }
+
+            charsWritten = value.Length;
+            value.AsSpan().CopyTo(destination);
+            return true;
+        }
+    }
+}
+
+#endif

--- a/RecordParser.Test/Parse.cs
+++ b/RecordParser.Test/Parse.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+
+namespace RecordParser.Test
+{
+    internal static class Parse
+    {
+#if NETSTANDARD2_0 || NETFRAMEWORK
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static string ProcessSpan(ReadOnlySpan<char> span) => span.ToString();
+#else
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ReadOnlySpan<char> ProcessSpan(ReadOnlySpan<char> span) => span;
+#endif
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Int32(ReadOnlySpan<char> utf8Text, IFormatProvider provider = null) => int.Parse(ProcessSpan(utf8Text), NumberStyles.Integer, provider);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long Int64(ReadOnlySpan<char> utf8Text, IFormatProvider provider = null) => long.Parse(ProcessSpan(utf8Text), NumberStyles.Integer, provider);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static DateTime DateTimeExact(ReadOnlySpan<char> utf8Text, string format, IFormatProvider provider = null) => DateTime.ParseExact(ProcessSpan(utf8Text), format, provider, DateTimeStyles.AllowWhiteSpaces);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static decimal Decimal(ReadOnlySpan<char> utf8Text, IFormatProvider provider = null) => decimal.Parse(ProcessSpan(utf8Text), NumberStyles.Number, provider);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TEnum Enum<TEnum>(ReadOnlySpan<char> utf8Text) where TEnum : struct, Enum
+        {
+#if NETSTANDARD2_0 || NETFRAMEWORK
+            return (TEnum)System.Enum.Parse(typeof(TEnum), utf8Text.ToString());
+#elif NETSTANDARD2_1
+            return System.Enum.Parse<TEnum>(utf8Text.ToString());
+#else
+            return System.Enum.Parse<TEnum>(utf8Text);
+#endif
+        }
+    }
+}

--- a/RecordParser.Test/QuotedFileReaderTest.cs
+++ b/RecordParser.Test/QuotedFileReaderTest.cs
@@ -52,7 +52,7 @@ namespace RecordParser.Test
                 a,1
                 ", 3,b , "4"
                 a,b,c,d
-                """.Replace(Environment.NewLine, newline);
+                """.Replace("\r\n", newline);
 
             var expected = new[]
             {
@@ -119,7 +119,7 @@ namespace RecordParser.Test
                 y",2,3,4
                 """;
 
-            var expected = ($"x{Environment.NewLine}y","2","3","4");
+            var expected = ("x\r\ny","2","3","4");
             var reader = new StringReader(fileContent);
             var options = new VariableLengthReaderRawOptions
             {

--- a/RecordParser.Test/RecordParser.Test.csproj
+++ b/RecordParser.Test/RecordParser.Test.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.17.0" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="xunit" Version="2.6.3" />
@@ -46,6 +46,12 @@
 
   <ItemGroup>
     <ProjectReference Include="..\RecordParser\RecordParser.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/RecordParser.Test/RecordParser.Test.csproj
+++ b/RecordParser.Test/RecordParser.Test.csproj
@@ -29,8 +29,11 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="morelinq" Version="3.3.2" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.6.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.collector" Version="1.0.1" />
   </ItemGroup>
 

--- a/RecordParser.Test/RecordParser.Test.csproj
+++ b/RecordParser.Test/RecordParser.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -32,6 +32,13 @@
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net472'">
+    <PackageReference Include="PolySharp" Version="1.14.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/RecordParser.Test/TextFindHelperTest.cs
+++ b/RecordParser.Test/TextFindHelperTest.cs
@@ -15,7 +15,7 @@ namespace RecordParser.Test
             var color = "LightBlue";
 
             var record = $"{id};{date};{color}";
-            var finder = new TextFindHelper(record, ";", ('"', "\""));
+            var finder = new TextFindHelper(record.AsSpan(), ";", ('"', "\""));
 
             // Act
 
@@ -50,7 +50,7 @@ namespace RecordParser.Test
 
             var action = () =>
             {
-                var finder = new TextFindHelper(record, ";", ('"', "\""));
+                var finder = new TextFindHelper(record.AsSpan(), ";", ('"', "\""));
 
                 a = finder.GetValue(0).ToString();
                 b = finder.GetValue(1).ToString();

--- a/RecordParser.Test/VariableLengthReaderBuilderQuotedFieldTest.cs
+++ b/RecordParser.Test/VariableLengthReaderBuilderQuotedFieldTest.cs
@@ -18,7 +18,7 @@ namespace RecordParser.Test
                 .Map(x => x.Price, 3)
                 .Build(",");
 
-            var result = reader.Parse("\"1997\",\"Ford\",\"Super, luxurious truck\",\"30100.99\"");
+            var result = reader.Parse("\"1997\",\"Ford\",\"Super, luxurious truck\",\"30100.99\"".AsSpan());
 
             result.Should().BeEquivalentTo((Year: 1997,
                                             Model: "Ford",
@@ -38,7 +38,7 @@ namespace RecordParser.Test
                 .Map(x => x.Price, 3)
                 .Build(separator);
 
-            var result = reader.Parse("  \"1997\"  ,  \"Ford\"  ,  \"Super, \"\"luxurious\"\" truck\"  ,  \"30100.99\"  ");
+            var result = reader.Parse("  \"1997\"  ,  \"Ford\"  ,  \"Super, \"\"luxurious\"\" truck\"  ,  \"30100.99\"  ".AsSpan());
 
             result.Should().BeEquivalentTo((Year: 1997,
                                             Model: "Ford",
@@ -56,7 +56,7 @@ namespace RecordParser.Test
                 .Map(x => x.Comment, 2)
                 .Build(separator);
 
-            var result = reader.Parse("  \"1997\"  ,  \"Ford\"  ,  \"Super, \"\"luxurious\"\" truck\"  ,  \"30100.99\"  ");
+            var result = reader.Parse("  \"1997\"  ,  \"Ford\"  ,  \"Super, \"\"luxurious\"\" truck\"  ,  \"30100.99\"  ".AsSpan());
 
             result.Should().BeEquivalentTo((Year: default(int),
                                             Model: default(string),
@@ -73,7 +73,7 @@ namespace RecordParser.Test
                 .Map(x => x.Price, 3)
                 .Build(separator);
 
-            var result = reader.Parse("  \"1997\"  ,  \"Ford\"  ,  \"Super, \"\"luxurious\"\" truck\"  ,  \"30100.99\"  ");
+            var result = reader.Parse("  \"1997\"  ,  \"Ford\"  ,  \"Super, \"\"luxurious\"\" truck\"  ,  \"30100.99\"  ".AsSpan());
 
             result.Should().BeEquivalentTo((Year: default(int),
                                             Model: default(string),
@@ -91,7 +91,7 @@ namespace RecordParser.Test
                 .Map(x => x.Price, 3)
                 .Build(",");
 
-            var result = reader.Parse("1997,Ford,\"Super, luxurious truck\",30100.99");
+            var result = reader.Parse("1997,Ford,\"Super, luxurious truck\",30100.99".AsSpan());
 
             result.Should().BeEquivalentTo((Year: 1997,
                                             Model: "Ford",
@@ -109,7 +109,7 @@ namespace RecordParser.Test
                 .Map(x => x.Price, 3)
                 .Build(",");
 
-            var result = reader.Parse("1997,Ford,\"\"\"It is fast\"\"\",30100.99");
+            var result = reader.Parse("1997,Ford,\"\"\"It is fast\"\"\",30100.99".AsSpan());
 
             result.Should().BeEquivalentTo((Year: 1997,
                                             Model: "Ford",
@@ -127,7 +127,7 @@ namespace RecordParser.Test
                 .Map(x => x.Price, 3)
                 .Build(",");
 
-            var result = reader.Parse("1997,Ford,\"\"\"It is fast\"\"\",30100.99");
+            var result = reader.Parse("1997,Ford,\"\"\"It is fast\"\"\",30100.99".AsSpan());
 
             result.Should().BeEquivalentTo((Year: 1997,
                                             Model: "FORD",
@@ -144,7 +144,7 @@ namespace RecordParser.Test
                 .Map(x => x.Price, 3)
                 .Build(",");
 
-            var result = reader.Parse("1997,Ford,\"Super, luxurious truck\",30100.99");
+            var result = reader.Parse("1997,Ford,\"Super, luxurious truck\",30100.99".AsSpan());
 
             result.Should().BeEquivalentTo((Year: 1997,
                                             Model: "Ford",
@@ -164,7 +164,7 @@ namespace RecordParser.Test
                 .Map(x => x.Price, 3)
                 .Build(",");
 
-            Action result = () => reader.Parse(line);
+            Action result = () => reader.Parse(line.AsSpan());
 
             result.Should().Throw<Exception>().WithMessage("Quoted field is missing closing quote.");
         }
@@ -180,7 +180,7 @@ namespace RecordParser.Test
                 .Map(x => x.Price, 3)
                 .Build(",");
 
-            Action result = () => reader.Parse(line);
+            Action result = () => reader.Parse(line.AsSpan());
 
             result.Should().Throw<Exception>().WithMessage("Double quote is not escaped or there is extra data after a quoted field.");
         }
@@ -195,7 +195,7 @@ namespace RecordParser.Test
                 .Map(x => x.Price, 3)
                 .Build(",");
 
-            var result = reader.Parse("1997,TV 47\", Super \"luxurious\" truck,30100.99");
+            var result = reader.Parse("1997,TV 47\", Super \"luxurious\" truck,30100.99".AsSpan());
 
             result.Should().BeEquivalentTo((Year: 1997,
                                             Model: "TV 47\"",
@@ -213,7 +213,7 @@ namespace RecordParser.Test
                 .Map(x => x.Price, 3)
                 .Build(",");
 
-            var result = reader.Parse("1997,Ford,\"Super, \"\"luxurious\"\" truck\",30100.99");
+            var result = reader.Parse("1997,Ford,\"Super, \"\"luxurious\"\" truck\",30100.99".AsSpan());
 
             result.Should().BeEquivalentTo((Year: 1997,
                                             Model: "Ford",
@@ -241,7 +241,7 @@ namespace RecordParser.Test
                 .Map(x => x.Owner, 4)
                 .Build(",");
 
-            var result = reader.Parse($"{model},1997,{comment},30100.99,{owner}");
+            var result = reader.Parse($"{model},1997,{comment},30100.99,{owner}".AsSpan());
 
             result.Should().BeEquivalentTo((Model: model,
                                             Year: 1997,
@@ -260,7 +260,7 @@ namespace RecordParser.Test
                 .Map(x => x.Price, 3)
                 .Build(",");
 
-            var result = reader.Parse("\"\n1997\",Ford \n Model, Super \"luxu\nrious\" truck,30100.99\n");
+            var result = reader.Parse("\"\n1997\",Ford \n Model, Super \"luxu\nrious\" truck,30100.99\n".AsSpan());
 
             result.Should().BeEquivalentTo((Year: 1997,
                                             Model: "Ford \n Model",

--- a/RecordParser.Test/VariableLengthWriterBuilderTest.cs
+++ b/RecordParser.Test/VariableLengthWriterBuilderTest.cs
@@ -1,7 +1,6 @@
 ﻿using AutoFixture;
 using FluentAssertions;
 using RecordParser.Builders.Writer;
-using RecordParser.Test;
 using System;
 using System.Linq;
 using Xunit;
@@ -220,7 +219,7 @@ namespace RecordParser.Test
                 .Map(x => x.Date, 1)
                 .Map(x => x.Debit, 2)
                 .DefaultTypeConvert<decimal>((span, value) => (((long)(value * 100)).TryFormat(span, out var written), written))
-                .DefaultTypeConvert<DateTime>((span, value) => (value.TryFormat(span, out var written, "ddMMyyyy"), written))
+                .DefaultTypeConvert<DateTime>((span, value) => (value.TryFormat(span, out var written, "ddMMyyyy".AsSpan()), written))
                 .Build(" ; ");
 
             var instance = (Balance: 0123456789.01M,
@@ -252,7 +251,7 @@ namespace RecordParser.Test
 
             var writer = new VariableLengthWriterBuilder<(string Name, DateTime Birthday, decimal Money, string Nickname)>()
                 .Map(x => x.Name, 1, SpanExtensions.ToUpperInvariant)
-                .Map(x => x.Birthday, 2, (span, date) => (date.TryFormat(span, out var written, "ddMMyyyy"), written))
+                .Map(x => x.Birthday, 2, (span, date) => (date.TryFormat(span, out var written, "ddMMyyyy".AsSpan()), written))
                 .Map(x => x.Money, 3)
                 .Map(x => x.Nickname, 4, (span, text) => SpanExtensions.ToUpperInvariant(span, text.Slice(0, 4)))
                 .Build(" ; ");

--- a/RecordParser.Test/VariableLengthWriterSequentialBuilderTest.cs
+++ b/RecordParser.Test/VariableLengthWriterSequentialBuilderTest.cs
@@ -226,7 +226,7 @@ namespace RecordParser.Test
                 .Map(x => x.Date)
                 .Map(x => x.Debit)
                 .DefaultTypeConvert<decimal>((span, value) => (((long)(value * 100)).TryFormat(span, out var written), written))
-                .DefaultTypeConvert<DateTime>((span, value) => (value.TryFormat(span, out var written, "ddMMyyyy"), written))
+                .DefaultTypeConvert<DateTime>((span, value) => (value.TryFormat(span, out var written, "ddMMyyyy".AsSpan()), written))
                 .Build(" ; ");
 
             var instance = (Balance: 0123456789.01M,
@@ -259,7 +259,7 @@ namespace RecordParser.Test
             var writer = new VariableLengthWriterSequentialBuilder<(string Name, DateTime Birthday, decimal Money, string Nickname)>()
                 .Skip(1)
                 .Map(x => x.Name, SpanExtensions.ToUpperInvariant)
-                .Map(x => x.Birthday, (span, date) => (date.TryFormat(span, out var written, "ddMMyyyy"), written))
+                .Map(x => x.Birthday, (span, date) => (date.TryFormat(span, out var written, "ddMMyyyy".AsSpan()), written))
                 .Map(x => x.Money)
                 .Map(x => x.Nickname, (span, text) => SpanExtensions.ToUpperInvariant(span, text.Slice(0, 4)))
                 .Build(" ; ");

--- a/RecordParser.Test/xunit.runner.json
+++ b/RecordParser.Test/xunit.runner.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+    "appDomain": "ifAvailable",
+    "shadowCopy": false,
+    "parallelizeTestCollections": false,
+    "maxParallelThreads": 1
+}

--- a/RecordParser.sln
+++ b/RecordParser.sln
@@ -12,6 +12,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C0189076-8DB4-4B93-91EE-BFF5DE424ACE}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		testenvironments.json = testenvironments.json
 	EndProjectSection
 EndProject
 Global

--- a/RecordParser.sln
+++ b/RecordParser.sln
@@ -1,13 +1,18 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29519.181
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34330.188
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RecordParser", "RecordParser\RecordParser.csproj", "{BA47D31A-475B-452F-BDE1-604465A57811}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RecordParser.Test", "RecordParser.Test\RecordParser.Test.csproj", "{DD1F677C-4BFE-4772-A2D7-C507F2B9C0A9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RecordParser.Benchmark", "RecordParser.Benchmark\RecordParser.Benchmark.csproj", "{D0F836BF-821C-49CE-994E-E4C866B5B7DC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RecordParser.Benchmark", "RecordParser.Benchmark\RecordParser.Benchmark.csproj", "{D0F836BF-821C-49CE-994E-E4C866B5B7DC}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C0189076-8DB4-4B93-91EE-BFF5DE424ACE}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/RecordParser/Engines/Writer/QuoteCSVWrite.cs
+++ b/RecordParser/Engines/Writer/QuoteCSVWrite.cs
@@ -50,7 +50,7 @@ namespace RecordParser.Engines.Writer
                     return (false, 0);
                 }
 
-                var newLengh = MinLengthToQuote(text, separator, quote);
+                var newLengh = MinLengthToQuote(text, separator.AsSpan(), quote);
 
                 return TryFormat(text, span, quote, newLengh);
             };
@@ -64,7 +64,7 @@ namespace RecordParser.Engines.Writer
 #endif
                 (Span<char> span, ReadOnlySpan<char> text) =>
                 {
-                    var newLengh = MinLengthToQuote(text, separator, quote);
+                    var newLengh = MinLengthToQuote(text, separator.AsSpan(), quote);
 
                     if (newLengh == text.Length)
                         return f(span, text);
@@ -101,7 +101,7 @@ namespace RecordParser.Engines.Writer
 #endif
                 (Span<char> span, string text) =>
                 {
-                    var newLengh = MinLengthToQuote(text, separator, quote);
+                    var newLengh = MinLengthToQuote(text.AsSpan(), separator.AsSpan(), quote);
 
                     if (newLengh == text.Length)
                         return f(span, text);
@@ -115,12 +115,12 @@ namespace RecordParser.Engines.Writer
                                             : stackalloc char[newLengh])
                                           .Slice(0, newLengh);
 
-                        var (success, written) = TryFormat(text, temp, quote, newLengh);
+                        var (success, written) = TryFormat(text.AsSpan(), temp, quote, newLengh);
 
                         Debug.Assert(success);
                         Debug.Assert(written == newLengh);
 
-                        return f(span, new string(temp));
+                        return f(span, temp.ToString());
                     }
                     finally
                     {

--- a/RecordParser/Engines/Writer/WriteEngine.cs
+++ b/RecordParser/Engines/Writer/WriteEngine.cs
@@ -79,11 +79,17 @@ namespace RecordParser.Engines.Writer
                     _ when prop.Type == typeof(char) || prop.Type == typeof(bool) =>
                         Expression.Call(typeof(WriteEngine), "TryFormat", Type.EmptyTypes, prop, temp, charsWritten),
 
+#if NETSTANDARD2_0
+                    _ => Expression.Call(typeof(Format), "TryFormat", [prop.Type], prop, temp, charsWritten, format,
+                        Expression.Constant(cultureInfo, typeof(CultureInfo))),
+#else
+
                     _ when prop.Type == typeof(Guid) =>
                         Expression.Call(prop, "TryFormat", Type.EmptyTypes, temp, charsWritten, format),
 
                     _ => Expression.Call(prop, "TryFormat", Type.EmptyTypes, temp, charsWritten, format,
                             Expression.Constant(cultureInfo, typeof(CultureInfo)))
+#endif
                 };
 
                 return Expression.IfThen(Expression.Not(tryFormat), gotoReturn);

--- a/RecordParser/Format.cs
+++ b/RecordParser/Format.cs
@@ -1,0 +1,25 @@
+﻿#if NETSTANDARD2_0
+
+using System;
+
+namespace RecordParser
+{
+    internal static class Format
+    {
+        public static bool TryFormat<T>(this T @this, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider provider = null) where T : IFormattable
+        {
+            string value = @this.ToString(format.ToString(), provider);
+            if (value.Length > destination.Length)
+            {
+                charsWritten = 0;
+                return false;
+            }
+
+            charsWritten = value.Length;
+            value.AsSpan().CopyTo(destination);
+            return true;
+        }
+    }
+}
+
+#endif

--- a/RecordParser/Parse.cs
+++ b/RecordParser/Parse.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+
+namespace RecordParser
+{
+    internal static class Parse
+    {
+#if NETSTANDARD2_0 || NETFRAMEWORK
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static string ProcessSpan(ReadOnlySpan<char> span) => span.ToString();
+#else
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ReadOnlySpan<char> ProcessSpan(ReadOnlySpan<char> span) => span;
+#endif
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static byte Byte(ReadOnlySpan<char> utf8Text, IFormatProvider provider = null) => byte.Parse(ProcessSpan(utf8Text), NumberStyles.Integer, provider);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static sbyte SByte(ReadOnlySpan<char> utf8Text, IFormatProvider provider = null) => sbyte.Parse(ProcessSpan(utf8Text), NumberStyles.Integer, provider);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Double(ReadOnlySpan<char> utf8Text, IFormatProvider provider = null) => double.Parse(ProcessSpan(utf8Text), NumberStyles.AllowThousands | NumberStyles.Float, provider);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Single(ReadOnlySpan<char> utf8Text, IFormatProvider provider = null) => float.Parse(ProcessSpan(utf8Text), NumberStyles.AllowThousands | NumberStyles.Float, provider);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Int32(ReadOnlySpan<char> utf8Text, IFormatProvider provider = null) => int.Parse(ProcessSpan(utf8Text), NumberStyles.Integer, provider);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static uint UInt32(ReadOnlySpan<char> utf8Text, IFormatProvider provider = null) => uint.Parse(ProcessSpan(utf8Text), NumberStyles.Integer, provider);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long Int64(ReadOnlySpan<char> utf8Text, IFormatProvider provider = null) => long.Parse(ProcessSpan(utf8Text), NumberStyles.Integer, provider);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ulong UInt64(ReadOnlySpan<char> utf8Text, IFormatProvider provider = null) => ulong.Parse(ProcessSpan(utf8Text), NumberStyles.Integer, provider);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static short Int16(ReadOnlySpan<char> utf8Text, IFormatProvider provider = null) => short.Parse(ProcessSpan(utf8Text), NumberStyles.Integer, provider);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ushort UInt16(ReadOnlySpan<char> utf8Text, IFormatProvider provider = null) => ushort.Parse(ProcessSpan(utf8Text), NumberStyles.Integer, provider);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Guid Guid(ReadOnlySpan<char> utf8Text) => System.Guid.Parse(ProcessSpan(utf8Text));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static DateTime DateTime(ReadOnlySpan<char> utf8Text, IFormatProvider provider = null) => System.DateTime.Parse(ProcessSpan(utf8Text), provider, DateTimeStyles.AllowWhiteSpaces);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TimeSpan TimeSpan(ReadOnlySpan<char> utf8Text, IFormatProvider provider = null) => System.TimeSpan.Parse(ProcessSpan(utf8Text), provider);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool Boolean(ReadOnlySpan<char> utf8Text) => bool.Parse(ProcessSpan(utf8Text));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static decimal Decimal(ReadOnlySpan<char> utf8Text, IFormatProvider provider = null) => decimal.Parse(ProcessSpan(utf8Text), NumberStyles.Number, provider);
+    }
+}

--- a/RecordParser/Parsers/VariableLengthWriter.cs
+++ b/RecordParser/Parsers/VariableLengthWriter.cs
@@ -22,7 +22,7 @@ namespace RecordParser.Parsers
 
         public bool TryFormat(T instance, Span<char> destination, out int charsWritten)
         {
-            var result = parse(destination, separator, instance);
+            var result = parse(destination, separator.AsSpan(), instance);
 
             charsWritten = result.charsWritten;
             return result.success;

--- a/RecordParser/RecordParser.csproj
+++ b/RecordParser/RecordParser.csproj
@@ -2,45 +2,53 @@
 
   <PropertyGroup>
     <PackageId>RecordParser</PackageId>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Authors>Leandro Fernandes Vieira (leandromoh)</Authors>
     <Description>
-	RecordParser is a expression tree based parser that helps you to write maintainable parsers with high-performance and zero allocations, thanks to Span type.  
-	It makes easier for developers to do parsing by automating non-relevant code, which allow you to focus on the essentials of mapping.  
-	Include readers and writers for variable-length and fixed-length records.  
+      RecordParser is a expression tree based parser that helps you to write maintainable parsers with high-performance and zero allocations, thanks to Span type.
+      It makes easier for developers to do parsing by automating non-relevant code, which allow you to focus on the essentials of mapping.
+      Include readers and writers for variable-length and fixed-length records.
     </Description>
     <Copyright>Copyright 2023 (c) Leandro F. Vieira (leandromoh). All rights reserved.</Copyright>
     <PackageProjectUrl>https://github.com/leandromoh/RecordParser</PackageProjectUrl>
     <RepositoryUrl>https://github.com/leandromoh/RecordParser</RepositoryUrl>
     <PackageTags>tsv parser performance csv mapper file flat reader dotnet-core span flatfile expression-tree delimited fixedlength</PackageTags>
-    <Version>2.3.0</Version>
+    <Version>2.3.1</Version>
     <PackageReleaseNotes>
-     https://github.com/leandromoh/RecordParser/blob/master/release_notes.md
+      https://github.com/leandromoh/RecordParser/blob/master/release_notes.md
     </PackageReleaseNotes>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>
-      <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
-      <NoWarn>1591</NoWarn>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-      <None Include="..\LICENSE.md" Pack="true" PackagePath="LICENSE.md"/>
+    <None Include="..\LICENSE.md" Pack="true" PackagePath="LICENSE.md" />
   </ItemGroup>
 
-    <ItemGroup>
-        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-            <_Parameter1>RecordParser.Test</_Parameter1>
-        </AssemblyAttribute>
-    </ItemGroup>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>RecordParser.Test</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 
   <PropertyGroup Condition="
 		( '$(Configuration)' == 'Debug' OR '$(Configuration)' == 'Release') AND
 		( '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0') AND
 		( '$(Platform)' == 'AnyCPU') ">
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="PolySharp" Version="1.14.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
 </Project>

--- a/RecordParser/Shims.cs
+++ b/RecordParser/Shims.cs
@@ -1,0 +1,33 @@
+﻿#if NETSTANDARD2_0
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace RecordParser
+{
+    internal static class Shims
+    {
+        public static bool Contains(this string @this, char charToFind) => @this.IndexOf(charToFind) != -1;
+
+        public static bool StartsWith(this ReadOnlySpan<char> @this, string value) => @this.StartsWith(value.AsSpan());
+
+        public static bool EndsWith(this ReadOnlySpan<char> @this, string value) => @this.EndsWith(value.AsSpan());
+
+        public static int IndexOf(this ReadOnlySpan<char> @this, string value) => @this.IndexOf(value.AsSpan());
+
+        public static bool TryPop<T>(this Stack<T> stack, [MaybeNullWhen(false)] out T result)
+        {
+            if (stack.Count > 0)
+            {
+                result = stack.Pop();
+                return true;
+            }
+
+            result = default;
+            return false;
+        }
+    }
+}
+
+#endif

--- a/testenvironments.json
+++ b/testenvironments.json
@@ -1,0 +1,10 @@
+{
+    "version": "1",
+    "environments": [
+        {
+            "name": "Ubuntu",
+            "type": "wsl",
+            "wslDistribution": "Ubuntu"
+        }
+    ]
+}


### PR DESCRIPTION
With a touch of PolySharp and a few shim methods, it's possible to get this library working in .NET Standard 2.0, and hence .NET Framework 4.x.